### PR TITLE
Convert Element Usage en Basic Shape

### DIFF
--- a/COMETwebapp.Tests/Viewer/MatrixExtensionsTests.cs
+++ b/COMETwebapp.Tests/Viewer/MatrixExtensionsTests.cs
@@ -1,0 +1,88 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SceneTests.cs" company="RHEA System S.A.">
+//    Copyright (c) 2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
+//
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Viewer
+{
+    using Bunit;
+
+    using COMETwebapp.Components.Viewer;
+    using COMETwebapp.Primitives;
+    using COMETwebapp.SessionManagement;
+    using COMETwebapp.Utilities;
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using TestContext = Bunit.TestContext;
+
+    /// <summary>
+    /// Matrix tests that verifies the correct behavior of the extension methods
+    /// </summary>
+    [TestFixture]
+    public class MatrixEstensionsTests
+    {
+        private double[] identity;
+        private double[] matrix1;
+        private double[] matrix2;
+
+        private const double delta = 0.01;
+
+        [SetUp]
+        public void SetUp()
+        {
+            identity = new double[] { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+            matrix1 = new double[]  { 0.5, 0, 0.8660254, 0, 1, 0, -0.8660254, 0, 0.5 };
+            matrix2 = new double[]  { 0.3894127, -0.4119121, 0.8238241, 0.4119121,  0.8778825,  0.2442349, -0.8238241,  0.2442349,  0.5115302  };
+        }
+
+        [Test]
+        public void VerifyThatIdentityDontChangeOrientation()
+        {
+            var angles = identity.ToEulerAngles();
+            Assert.AreEqual(0, angles[0], delta);
+            Assert.AreEqual(0, angles[1], delta);
+            Assert.AreEqual(0, angles[2], delta);
+        }
+
+        [Test]
+        public void VerifyThatAnglesCanBeExtractedFromMatrix1()
+        {
+            var angles = matrix1.ToEulerAngles();
+            Assert.AreEqual(0, angles[0], delta);
+            Assert.AreEqual(1.0471976, angles[1], delta);
+            Assert.AreEqual(0, angles[2], delta);
+        }
+
+        [Test]
+        public void VerifyThatAnglesCanBeExtractedFromMatrix2()
+        {
+            var angles = matrix2.ToEulerAngles();
+            Assert.AreEqual(0.4454531, angles[0], delta);
+            Assert.AreEqual(0.9681246, angles[1], delta);
+            Assert.AreEqual(0.8134685, angles[2], delta);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Viewer/MatrixExtensionsTests.cs
+++ b/COMETwebapp.Tests/Viewer/MatrixExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="SceneTests.cs" company="RHEA System S.A.">
+// <copyright file="MatrixEstensionsTests.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
@@ -24,19 +24,9 @@
 
 namespace COMETwebapp.Tests.Viewer
 {
-    using Bunit;
-
-    using COMETwebapp.Components.Viewer;
-    using COMETwebapp.Primitives;
-    using COMETwebapp.SessionManagement;
     using COMETwebapp.Utilities;
-    using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
-
-    using TestContext = Bunit.TestContext;
 
     /// <summary>
     /// Matrix tests that verifies the correct behavior of the extension methods

--- a/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
+++ b/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
@@ -29,10 +29,12 @@ namespace COMETwebapp.Tests.Viewer
     using System.Collections.Generic;
 
     using Bunit;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
+
     using COMETwebapp.Components.Viewer;
     using COMETwebapp.Primitives;
     using COMETwebapp.SessionManagement;

--- a/COMETwebapp/Components/Viewer/BabylonCanvasBase.cs
+++ b/COMETwebapp/Components/Viewer/BabylonCanvasBase.cs
@@ -152,6 +152,8 @@ namespace COMETwebapp.Componentes.Viewer
         {
             await Scene.ClearPrimitives();
 
+            Random rand = new Random();
+
             foreach (var elementUsage in elementUsages)
             {
                 var basicShape = this.ShapeFactory.TryGetPrimitiveFromElementUsageParameter(elementUsage, selectedOption, states);
@@ -167,9 +169,13 @@ namespace COMETwebapp.Componentes.Viewer
                         basicPrimitive.SetDimensionsFromElementUsageParameters(elementUsage, selectedOption, states);
                     }
 
-                    await Scene.AddPrimitive(basicShape);
+                    //TODO: When materiales can be added this should not be random. For now helps distinguish different shapes on scene.
+                    int r = rand.Next(0, 225);
+                    int g = rand.Next(0, 225);
+                    int b = rand.Next(0, 225);
+
+                    await Scene.AddPrimitive(basicShape, Color.FromArgb(r,g,b));
                 }
-                //await Task.Delay(1000);
             }
         }
     }

--- a/COMETwebapp/Components/Viewer/BabylonCanvasBase.cs
+++ b/COMETwebapp/Components/Viewer/BabylonCanvasBase.cs
@@ -158,14 +158,18 @@ namespace COMETwebapp.Componentes.Viewer
 
                 if (basicShape is not null)
                 {
+                    basicShape.ElementUsageName = elementUsage.Name;
+
                     if (basicShape is BasicPrimitive basicPrimitive)
                     {
-                        basicPrimitive.SetPositionFromElementUsageParameters(elementUsage, selectedOption, states);
+                        basicPrimitive.SetOrientationFromElementUsageParameters(elementUsage, selectedOption, states);
+                        basicPrimitive.SetPositionFromElementUsageParameters(elementUsage, selectedOption, states);                        
                         basicPrimitive.SetDimensionsFromElementUsageParameters(elementUsage, selectedOption, states);
                     }
 
                     await Scene.AddPrimitive(basicShape);
                 }
+                //await Task.Delay(1000);
             }
         }
     }

--- a/COMETwebapp/Primitives/BasicPrimitive.cs
+++ b/COMETwebapp/Primitives/BasicPrimitive.cs
@@ -26,6 +26,8 @@ namespace COMETwebapp.Primitives
 {
     using CDP4Common.EngineeringModelData;
 
+    using COMETwebapp.Utilities;
+
     /// <summary>
     /// Class fot primitives that can be positioned and rotated in space
     /// </summary>
@@ -158,8 +160,45 @@ namespace COMETwebapp.Primitives
                 double.TryParse(valueSet.ActualValue[1], out var y) &&
                 double.TryParse(valueSet.ActualValue[2], out var z))
             {
-                this.SetTranslation(x / 1000.0, y / 1000.0, z / 1000.0);
+                this.SetTranslation(x, y, z);
             }            
+        }
+
+        /// <summary>
+        /// Set the orientation of the <see cref="BasicPrimitive"/> from the <see cref="ElementUsage"/> parameters
+        /// </summary>
+        /// <param name="elementUsage">the <see cref="ElementUsage"/> used for the orientation</param>
+        /// <param name="selectedOption">the current <see cref="Option"/> selected</param>
+        /// <param name="states">the <see cref="ActualFiniteState"/> that are going to be used to orient the <see cref="BasicPrimitive"/></param>
+        public void SetOrientationFromElementUsageParameters(ElementUsage elementUsage, Option selectedOption, List<ActualFiniteState> states)
+        {
+            IValueSet? valueSet = null;
+
+            valueSet = this.GetElementUsageValueSet(elementUsage, selectedOption, states, Scene.OrientationShortName);
+
+            if (valueSet is not null)
+            {
+                double[] rotMatrix = new double[9];
+
+                if(valueSet.ActualValue.Any(x => { return (x == "-" || x == string.Empty); }))
+                {
+                    rotMatrix[0] = rotMatrix[4] = rotMatrix[8] = 1.0;                    
+                }
+                else
+                {
+                    for (int i = 0; i < 9; i++)
+                    {
+                        rotMatrix[i] = double.Parse(valueSet.ActualValue[i]);
+                    }
+                }
+
+                if (rotMatrix.Length == 9)
+                {
+                    double[] angles = rotMatrix.ToEulerAngles();
+
+                    this.SetRotation(angles[0], angles[1], angles[2]);
+                }
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -26,8 +26,6 @@ namespace COMETwebapp.Primitives
 {
     using System.Numerics;
 
-    using CDP4Common.EngineeringModelData;
-
     /// <summary>
     /// Base class for the wrapper classes around JS objects. Represents an object on the Scene.
     /// </summary>

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -26,11 +26,18 @@ namespace COMETwebapp.Primitives
 {
     using System.Numerics;
 
+    using CDP4Common.EngineeringModelData;
+
     /// <summary>
     /// Base class for the wrapper classes around JS objects. Represents an object on the Scene.
     /// </summary>
     public abstract class Primitive
     {
+        /// <summary>
+        /// The element usage name the primitive was created from
+        /// </summary>
+        public string ElementUsageName { get; set; }
+
         /// <summary>
         /// The base color of the primitive
         /// </summary>

--- a/COMETwebapp/Primitives/ShapeFactory.cs
+++ b/COMETwebapp/Primitives/ShapeFactory.cs
@@ -27,7 +27,6 @@ namespace COMETwebapp.Primitives
     using System.Collections.Generic;
 
     using CDP4Common.EngineeringModelData;
-    using CDP4Common.SiteDirectoryData;
 
     /// <summary>
     /// The factory used for creating basic shapes of type <see cref="Primitive"/>

--- a/COMETwebapp/Primitives/ShapeFactory.cs
+++ b/COMETwebapp/Primitives/ShapeFactory.cs
@@ -43,42 +43,59 @@ namespace COMETwebapp.Primitives
         /// <returns>The created <see cref="Primitive"/></returns>
         public Primitive TryGetPrimitiveFromElementUsageParameter(ElementUsage elementUsage, Option selectedOption, List<ActualFiniteState> states)
         {
-            var parameter = elementUsage.ElementDefinition.Parameter.FirstOrDefault(x => x.ParameterType.ShortName == "kind"
-                      && (x.ParameterType is EnumerationParameterType || x.ParameterType is TextParameterType));
-
+            ParameterBase? parameterBase = null;
             IValueSet? valueSet = null;
 
-            if (parameter is not null)
+            if (elementUsage.ParameterOverride.Count > 0)
             {
-                foreach (var actualFiniteState in states)
+                parameterBase = elementUsage.ParameterOverride.FirstOrDefault(x => x.ParameterType.ShortName == Scene.ShapeKindShortName
+                                                                                   && x.ParameterType.GetType() == Scene.GetParameterTypeFromParameterShortName(Scene.ShapeKindShortName));
+            }
+
+            if (parameterBase is null)
+            {
+                parameterBase = elementUsage.ElementDefinition.Parameter.FirstOrDefault(x => x.ParameterType.ShortName == Scene.ShapeKindShortName
+                                                                                             && x.ParameterType.GetType() == Scene.GetParameterTypeFromParameterShortName(Scene.ShapeKindShortName));
+            }
+
+            if (parameterBase is not null)
+            {
+                if (states.Count > 0)
                 {
-                    valueSet = parameter.QueryParameterBaseValueSet(selectedOption, actualFiniteState);
-                    if (valueSet is not null)
+                    foreach (var actualFiniteState in states)
                     {
-                        break;
+                        valueSet = parameterBase.QueryParameterBaseValueSet(selectedOption, actualFiniteState);
+                        if (valueSet is not null)
+                        {
+                            break;
+                        }
                     }
+                }
+                else
+                {
+                    valueSet = parameterBase.QueryParameterBaseValueSet(selectedOption, null);
                 }
             }
 
-            if(valueSet is not null)
+            if (valueSet is not null)
             {
                 string? shapeKind = valueSet.ActualValue.FirstOrDefault()?.ToLowerInvariant();
                 switch (shapeKind)
                 {
-                    case "box": return new Cube(1, 1, 1);
-                    case "cylinder": return new Cylinder(1, 1);
+                    case "box": return new Cube(0.15,0.15,0.15);
+                    case "cylinder": return new Cylinder(0.1, 1);
                     case "sphere": return new Sphere(1);
                     case "torus": return new Torus(1, 1);
                     case "triprism": throw new NotImplementedException();
                     case "tetrahedron": throw new NotImplementedException();
                     case "capsule": throw new NotImplementedException();
                     
-                    default: return new Cube(1, 1, 1); 
+                    default: return new Cube(0.15, 0.15, 0.15); 
                 }
             }
             else
             {
-                return new Cube(1, 1, 1);
+                return new Cube(0.15, 0.15, 0.15);
             }      
         }
     }

--- a/COMETwebapp/Scene.cs
+++ b/COMETwebapp/Scene.cs
@@ -84,11 +84,6 @@ namespace COMETwebapp
         public const string ThicknessShortName = "thickn";
 
         /// <summary>
-        /// Collection of temporary <see cref="Primitive"/> in the Scene. 
-        /// </summary>
-        private static Dictionary<string, Primitive> temporaryPrimitivesCollection = new Dictionary<string, Primitive>();
-
-        /// <summary>
         /// Collection of the <see cref="Primitive"/> in the Scene
         /// </summary>
         private static Dictionary<string, Primitive> primitivesCollection = new Dictionary<string, Primitive>();
@@ -173,30 +168,6 @@ namespace COMETwebapp
         }
 
         /// <summary>
-        /// Adds a temporary primitive to the scene
-        /// </summary>
-        /// <param name="primitive">The primitive to add</param>
-        public static async Task AddTemporaryPrimitive(Primitive primitive)
-        {
-            await AddTemporaryPrimitive(primitive, Color.LightGray);
-        }
-
-        /// <summary>
-        /// Adds a temporary primitive to the scene with the specified color
-        /// </summary>
-        /// <param name="primitive">the primitive to add</param>
-        /// <param name="color">the color of the primitive</param>
-        public static async Task AddTemporaryPrimitive(Primitive primitive, Color color)
-        {
-            string jsonPrimitive = JsonConvert.SerializeObject(primitive, Formatting.Indented);
-            Vector3 colorVectorized = new Vector3(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f);
-            string jsonColor = JsonConvert.SerializeObject(colorVectorized, Formatting.Indented);
-
-            primitivesCollection.Add(primitive.ID, primitive);
-            await JSInterop.Invoke("AddPrimitive", jsonPrimitive, jsonColor);
-        }
-
-        /// <summary>
         /// Clears the scene deleting the primitives that contains
         /// </summary>
         public static async Task ClearPrimitives()
@@ -207,19 +178,6 @@ namespace COMETwebapp
                 await JSInterop.Invoke("Dispose", id);
             }
             primitivesCollection.Clear();
-        }
-
-        /// <summary>
-        /// Clears the scene deleting the temporary primitives
-        /// </summary>
-        public static async Task ClearTemporaryPrimitives()
-        {
-            var keys = primitivesCollection.Keys.ToList();
-            foreach (var id in keys)
-            {
-                await JSInterop.Invoke("Dispose", id);
-            }
-            temporaryPrimitivesCollection.Clear();
         }
 
         /// <summary>

--- a/COMETwebapp/Utilities/MatrixExtensions.cs
+++ b/COMETwebapp/Utilities/MatrixExtensions.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="GuidExtensions.cs" company="RHEA System S.A.">
+// <copyright file="MatrixExtensions.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
-//    Author: Justine Veirier d'aiguebonne, Sam Gerené, Alex Vorobiev, Alexander van Delft
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
 //
 //    This file is part of COMET WEB Community Edition
 //    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
@@ -39,15 +39,15 @@ namespace COMETwebapp.Utilities
         {
             double Rx = 0, Ry = 0, Rz = 0;
 
-            if(rotMatrix.Length < 9)
+            if (rotMatrix.Length < 9)
             {
                 throw new ArgumentException("The rotation Matrix needs to be at least 3x3 so at least an Array of 9 numbers is needed");
             }
 
-            if (rotMatrix[6]!= 1 && rotMatrix[6]!= -1)
+            if (rotMatrix[6] != 1 && rotMatrix[6] != -1)
             {
                 Ry = -Math.Asin(rotMatrix[6]);
-                Rx = Math.Atan2(rotMatrix[7]/Math.Cos(Ry), rotMatrix[8]/ Math.Cos(Ry));
+                Rx = Math.Atan2(rotMatrix[7] / Math.Cos(Ry), rotMatrix[8] / Math.Cos(Ry));
                 Rz = Math.Atan2(rotMatrix[3] / Math.Cos(Ry), rotMatrix[0] / Math.Cos(Ry));
             }
             else
@@ -56,16 +56,15 @@ namespace COMETwebapp.Utilities
                 if (rotMatrix[6] == -1)
                 {
                     Ry = Math.PI / 2.0;
-                    Rx = Ry + Math.Atan2(rotMatrix[1],rotMatrix[2]);
+                    Rx = Rz + Math.Atan2(rotMatrix[1], rotMatrix[2]);
                 }
                 else
                 {
                     Ry = -Math.PI / 2.0;
-                    Rx = -Ry + Math.Atan2(-rotMatrix[1],-rotMatrix[2]);
+                    Rx = -Rz + Math.Atan2(-rotMatrix[1], -rotMatrix[2]);
                 }
             }
             return new double[] { Rx, Ry, Rz };
         }
-
     }
 }

--- a/COMETwebapp/Utilities/MatrixExtensions.cs
+++ b/COMETwebapp/Utilities/MatrixExtensions.cs
@@ -1,14 +1,53 @@
-﻿namespace COMETwebapp.Utilities
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GuidExtensions.cs" company="RHEA System S.A.">
+//    Copyright (c) 2022 RHEA System S.A.
+//
+//    Author: Justine Veirier d'aiguebonne, Sam Gerené, Alex Vorobiev, Alexander van Delft
+//
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Utilities
 {
+    /// <summary>
+    /// Static extension methods 
+    /// </summary>
     public static class MatrixExtensions
     {
+        /// <summary>
+        /// Transforms the <param name="rotMatrix"/> that represents a rotation matrix of 3x3 to the rotation expressed in Euler Angles
+        /// </summary>
+        /// <param name="rotMatrix">the rotation matrix 3x3 stored in row-major order. For more info <see cref="https://en.wikipedia.org/wiki/Row-_and_column-major_order"/></param>
+        /// <returns>The Euler Angles in form [Rx,Ry,Rz]</returns>
+        /// <exception cref="ArgumentException">If the <paramref name="rotMatrix"/> can't be expressed as a 3x3 matrix </exception>
         public static double[] ToEulerAngles(this double[] rotMatrix)
         {
             double Rx = 0, Ry = 0, Rz = 0;
+
+            if(rotMatrix.Length < 9)
+            {
+                throw new ArgumentException("The rotation Matrix needs to be at least 3x3 so at least an Array of 9 numbers is needed");
+            }
+
             if (rotMatrix[6]!= 1 && rotMatrix[6]!= -1)
             {
                 Ry = -Math.Asin(rotMatrix[6]);
-                Rx = Math.Atan2(rotMatrix[7]/Math.Cos(Ry), rotMatrix[8]/Math.Cos(Ry));
+                Rx = Math.Atan2(rotMatrix[7]/Math.Cos(Ry), rotMatrix[8]/ Math.Cos(Ry));
                 Rz = Math.Atan2(rotMatrix[3] / Math.Cos(Ry), rotMatrix[0] / Math.Cos(Ry));
             }
             else

--- a/COMETwebapp/Utilities/MatrixExtensions.cs
+++ b/COMETwebapp/Utilities/MatrixExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace COMETwebapp.Utilities
+{
+    public static class MatrixExtensions
+    {
+        public static double[] ToEulerAngles(this double[] rotMatrix)
+        {
+            double Rx = 0, Ry = 0, Rz = 0;
+            if (rotMatrix[6]!= 1 && rotMatrix[6]!= -1)
+            {
+                Ry = -Math.Asin(rotMatrix[6]);
+                Rx = Math.Atan2(rotMatrix[7]/Math.Cos(Ry), rotMatrix[8]/Math.Cos(Ry));
+                Rz = Math.Atan2(rotMatrix[3] / Math.Cos(Ry), rotMatrix[0] / Math.Cos(Ry));
+            }
+            else
+            {
+                Rz = 0;
+                if (rotMatrix[6] == -1)
+                {
+                    Ry = Math.PI / 2.0;
+                    Rx = Ry + Math.Atan2(rotMatrix[1],rotMatrix[2]);
+                }
+                else
+                {
+                    Ry = -Math.PI / 2.0;
+                    Rx = -Ry + Math.Atan2(-rotMatrix[1],-rotMatrix[2]);
+                }
+            }
+            return new double[] { Rx, Ry, Rz };
+        }
+
+    }
+}

--- a/COMETwebapp/wwwroot/Scripts/babylonInterop.js
+++ b/COMETwebapp/wwwroot/Scripts/babylonInterop.js
@@ -215,11 +215,9 @@ function GetPrimitiveIDUnderMouse() {
     let pickedMesh = hit.pickedMesh;
 
     if (pickedMesh.CometID != "Skybox") {
-
         let data = Primitives.get(pickedMesh.CometID);
         if (data != undefined) {
             let primitiveData = data["primitive"];
-
             if (primitiveData != undefined) {
                 console.log(primitiveData.ElementUsageName);
             }
@@ -256,19 +254,15 @@ function GetPrimitiveByID(Id) {
  * @param {number} z - translation along the Z axis
  */
 function SetPrimitivePosition(ID, x, y, z) {
-    console.log("Set position enter. Translate to: " + x, y, z);
     if (Primitives.size > 0) {
         let data = Primitives.get(ID);
         if (data != undefined) {
             let mesh = data["mesh"];
-            console.log("Data: " + mesh.position);
             mesh.position.x = x;
             mesh.position.y = y;
             mesh.position.z = z;
-            console.log("Data: " + mesh.position);
         }
     }
-    console.log("---- FINISH POSITIONING ----")
 }
 
 /**
@@ -279,7 +273,6 @@ function SetPrimitivePosition(ID, x, y, z) {
  * @param {number} rz - the rotation around Z axis
  */
 function SetPrimitiveRotation(ID, rx, ry, rz) {
-    console.log("Set rotation enter. Rotate: " + rx, ry, rx);
     if (Primitives.size > 0) {
         let data = Primitives.get(ID);
         if (data != undefined) {
@@ -289,7 +282,6 @@ function SetPrimitiveRotation(ID, rx, ry, rz) {
             mesh.rotation.z = rz;
         }
     }
-    console.log("---- FINISH ROTATION ----")
 }
 
 /**

--- a/COMETwebapp/wwwroot/Scripts/babylonInterop.js
+++ b/COMETwebapp/wwwroot/Scripts/babylonInterop.js
@@ -215,6 +215,16 @@ function GetPrimitiveIDUnderMouse() {
     let pickedMesh = hit.pickedMesh;
 
     if (pickedMesh.CometID != "Skybox") {
+
+        let data = Primitives.get(pickedMesh.CometID);
+        if (data != undefined) {
+            let primitiveData = data["primitive"];
+
+            if (primitiveData != undefined) {
+                console.log(primitiveData.ElementUsageName);
+            }
+        }
+
         return pickedMesh.CometID;
     }
 
@@ -246,15 +256,19 @@ function GetPrimitiveByID(Id) {
  * @param {number} z - translation along the Z axis
  */
 function SetPrimitivePosition(ID, x, y, z) {
+    console.log("Set position enter. Translate to: " + x, y, z);
     if (Primitives.size > 0) {
         let data = Primitives.get(ID);
         if (data != undefined) {
             let mesh = data["mesh"];
+            console.log("Data: " + mesh.position);
             mesh.position.x = x;
             mesh.position.y = y;
             mesh.position.z = z;
+            console.log("Data: " + mesh.position);
         }
     }
+    console.log("---- FINISH POSITIONING ----")
 }
 
 /**
@@ -265,6 +279,7 @@ function SetPrimitivePosition(ID, x, y, z) {
  * @param {number} rz - the rotation around Z axis
  */
 function SetPrimitiveRotation(ID, rx, ry, rz) {
+    console.log("Set rotation enter. Rotate: " + rx, ry, rx);
     if (Primitives.size > 0) {
         let data = Primitives.get(ID);
         if (data != undefined) {
@@ -274,6 +289,7 @@ function SetPrimitiveRotation(ID, rx, ry, rz) {
             mesh.rotation.z = rz;
         }
     }
+    console.log("---- FINISH ROTATION ----")
 }
 
 /**


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The basic shapes can now be positioned, scaled and rotated properly.

<!-- Thanks for contributing to COMET-WEB! -->

