### PR TITLE
Selection from both ways

### DIFF
--- a/COMETwebapp/Components/Viewer/BabylonCanvasBase.cs
+++ b/COMETwebapp/Components/Viewer/BabylonCanvasBase.cs
@@ -102,23 +102,29 @@ namespace COMETwebapp.Componentes.Viewer
         /// Canvas on mouse down event
         /// </summary>
         /// <param name="e">the mouse args of the event</param>
-        public async void OnMouseDown(MouseEventArgs e)
+        public void OnMouseDown(MouseEventArgs e)
         {
             this.IsMouseDown = true;
             //TODO: when the tools are ready here we are going to manage the different types of actions that a user can make.
-            var prim = this.SceneProvider.GetPrimitives().FirstOrDefault(x => x is not Line);
-
-            var retrieved = this.SceneProvider.GetPrimitiveById(prim.ID);
         }
 
         /// <summary>
         /// Canvas on mouse up event
         /// </summary>
         /// <param name="e">the mouse args of the event</param>
-        public void OnMouseUp(MouseEventArgs e)
+        public async void OnMouseUp(MouseEventArgs e)
         {
             this.IsMouseDown = false;
             //TODO: when the tools are ready here we are going to manage the different types of actions that a user can make.
+
+            var primitive = await this.SceneProvider.GetPrimitiveUnderMouseAsync();
+
+            if (primitive is not null)
+            {
+                this.SceneProvider.GetPrimitives().ForEach(x => x.IsSelected = false);
+                primitive.IsSelected = true;
+                this.SceneProvider.RaiseSelectionChanged(primitive);
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/Components/Viewer/ISceneProvider.cs
+++ b/COMETwebapp/Components/Viewer/ISceneProvider.cs
@@ -27,10 +27,11 @@ namespace COMETwebapp.Components.Viewer
     using System.Drawing;
     using System.Numerics;
 
+    using COMETwebapp.Model;
     using COMETwebapp.Primitives;
 
     using Microsoft.AspNetCore.Components;
-    
+
     /// <summary>
     /// Scene provider
     /// </summary>
@@ -75,6 +76,11 @@ namespace COMETwebapp.Components.Viewer
         /// Thickness parameter short name
         /// </summary>
         public const string ThicknessShortName = "thickn";
+
+        /// <summary>
+        /// Event for when the selection has changed
+        /// </summary>
+        event EventHandler<OnSelectionChangedEventArgs> OnSelectionChanged;
 
         /// <summary>
         /// Inits the scene, the asociated resources and the render loop.
@@ -201,5 +207,11 @@ namespace COMETwebapp.Components.Viewer
         /// <param name="z">the z coordinate in world coordinates</param>
         /// <returns></returns>
         Task<Vector2?> GetScreenCoordinates(double x, double y, double z);
+
+        /// <summary>
+        /// Raise the <see cref="OnSelectionChanged"/> event 
+        /// </summary>
+        /// <param name="primitive">The <see cref="Primitive"/> that triggers the event</param>
+        void RaiseSelectionChanged(Primitive primitive);
     }
 }

--- a/COMETwebapp/Components/Viewer/SceneProvider.cs
+++ b/COMETwebapp/Components/Viewer/SceneProvider.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="Scene.cs" company="RHEA System S.A.">
+// <copyright file="SceneProvider.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
@@ -25,14 +25,15 @@
 namespace COMETwebapp.Components.Viewer
 {
     using System;
+    using System.Collections.Generic;
     using System.Drawing;
     using System.Numerics;
     using System.Threading.Tasks;
-    using System.Collections.Generic;
 
     using CDP4Common.SiteDirectoryData;
 
     using COMETwebapp;
+    using COMETwebapp.Model;
     using COMETwebapp.Primitives;
 
     using Microsoft.AspNetCore.Components;
@@ -41,7 +42,7 @@ namespace COMETwebapp.Components.Viewer
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Static class to access the resources of a Scene 
+    /// Class to access the resources of a Scene 
     /// </summary>
     public class SceneProvider : ISceneProvider
     {
@@ -105,11 +106,25 @@ namespace COMETwebapp.Components.Viewer
         };
 
         /// <summary>
+        /// Event for when selection has changed;
+        /// </summary>
+        public event EventHandler<OnSelectionChangedEventArgs> OnSelectionChanged;
+
+        /// <summary>
         /// Creates a new instance of class <see cref="SceneProvider"/>
         /// </summary>
         public SceneProvider(IJSRuntime JsRuntime)
         {
             JSInterop.JsRuntime = JsRuntime;
+        }
+
+        /// <summary>
+        /// Raise the <see cref="OnSelectionChanged"/> event 
+        /// </summary>
+        /// <param name="primitive">The <see cref="Primitive"/> that triggers the event</param>
+        public void RaiseSelectionChanged(Primitive primitive)
+        {
+            OnSelectionChanged?.Invoke(this, new OnSelectionChangedEventArgs(primitive));
         }
 
         /// <summary>

--- a/COMETwebapp/Model/OnSelectionChangedEventArgs.cs
+++ b/COMETwebapp/Model/OnSelectionChangedEventArgs.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OnSelectionChangedEventArgs.cs" company="RHEA System S.A.">
+//    Copyright (c) 2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
+//
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Model
+{
+    using COMETwebapp.Primitives;
+
+    /// <summary>
+    /// Arguments of the event
+    /// </summary>
+    public class OnSelectionChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The <see cref="Primitive"/> that triggers the selection changed
+        /// </summary>
+        public Primitive Primitive { get; }
+
+        /// <summary>
+        /// Creates a new instance of type <see cref="OnSelectionChangedEventArgs"/>
+        /// </summary>
+        /// <param name="primitive">the primitive that has been selected</param>
+        public OnSelectionChangedEventArgs(Primitive primitive)
+        {
+            this.Primitive = primitive;
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The selection of the primitives now works on both ways:
-Selecting a node in the tree updates the tree view and updates the selection state of the associated primitive.
-Selecting a primitive updates the tree view.

<!-- Thanks for contributing to COMET-WEB! -->

