### PR TITLE
The changes can be applied at runtime

### DIFF
--- a/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
+++ b/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
@@ -147,9 +147,9 @@ namespace COMETwebapp.Tests.Viewer
 
             var basicPrim = basicShape as BasicPrimitive;
 
-            Assert.AreNotEqual(0, basicPrim.X);
-            Assert.AreNotEqual(0, basicPrim.Y);
-            Assert.AreNotEqual(0, basicPrim.Z);
+            Assert.AreNotEqual(0.0, basicPrim.X);
+            Assert.AreNotEqual(0.0, basicPrim.Y);
+            Assert.AreNotEqual(0.0, basicPrim.Z);
         }
 
         [Test]
@@ -165,9 +165,9 @@ namespace COMETwebapp.Tests.Viewer
             var orientZ = basicPrim.RZ;
             basicPrim.SetOrientationFromElementUsageParameters();
 
-            Assert.AreNotEqual(0, basicPrim.RX);
-            Assert.AreNotEqual(0, basicPrim.RY);
-            Assert.AreNotEqual(0, basicPrim.RZ);
+            Assert.AreNotEqual(0.0, basicPrim.RX);
+            Assert.AreNotEqual(0.0, basicPrim.RY);
+            Assert.AreNotEqual(0.0, basicPrim.RZ);
         }
 
         [Test]
@@ -184,15 +184,15 @@ namespace COMETwebapp.Tests.Viewer
         {
             foreach (var primitive in this.positionables)
             {
-                Assert.AreEqual(0, primitive.X);
-                Assert.AreEqual(0, primitive.Y);
-                Assert.AreEqual(0, primitive.Z);
+                Assert.AreEqual(0.0, primitive.X);
+                Assert.AreEqual(0.0, primitive.Y);
+                Assert.AreEqual(0.0, primitive.Z);
 
-                primitive.SetTranslation(1, 1, 1);
+                primitive.SetTranslation(1.0, 1.0, 1.0);
 
-                Assert.AreEqual(1, primitive.X);
-                Assert.AreEqual(1, primitive.Y);
-                Assert.AreEqual(1, primitive.Z);
+                Assert.AreEqual(1.0, primitive.X);
+                Assert.AreEqual(1.0, primitive.Y);
+                Assert.AreEqual(1.0, primitive.Z);
             }
         }
 
@@ -201,35 +201,35 @@ namespace COMETwebapp.Tests.Viewer
         {
             foreach (var primitive in this.positionables)
             {
-                Assert.AreEqual(0, primitive.RX);
-                Assert.AreEqual(0, primitive.RY);
-                Assert.AreEqual(0, primitive.RZ);
+                Assert.AreEqual(0.0, primitive.RX);
+                Assert.AreEqual(0.0, primitive.RY);
+                Assert.AreEqual(0.0, primitive.RZ);
 
-                primitive.SetRotation(1, 1, 1);
+                primitive.SetRotation(1.0, 1.0, 1.0);
 
-                Assert.AreEqual(1, primitive.RX);
-                Assert.AreEqual(1, primitive.RY);
-                Assert.AreEqual(1, primitive.RZ);
+                Assert.AreEqual(1.0, primitive.RX);
+                Assert.AreEqual(1.0, primitive.RY);
+                Assert.AreEqual(1.0, primitive.RZ);
             }
         }
 
         [Test]
         public void VerifyThatTransformationsCanBeReseted()
         {
-            var cube = new Cube(1, 1, 1);
-            Assert.AreEqual(0, cube.X);
-            Assert.AreEqual(0, cube.Y);
-            Assert.AreEqual(0, cube.Z);
+            var cube = new Cube(1.0, 1.0, 1.0);
+            Assert.AreEqual(0.0, cube.X);
+            Assert.AreEqual(0.0, cube.Y);
+            Assert.AreEqual(0.0, cube.Z);
 
-            cube.SetTranslation(1, 2, 3);
-            Assert.AreEqual(1, cube.X);
-            Assert.AreEqual(2, cube.Y);
-            Assert.AreEqual(3, cube.Z);
+            cube.SetTranslation(1.0, 2.0, 3.0);
+            Assert.AreEqual(1.0, cube.X);
+            Assert.AreEqual(2.0, cube.Y);
+            Assert.AreEqual(3.0, cube.Z);
 
             cube.ResetTransformations();
-            Assert.AreEqual(0, cube.X);
-            Assert.AreEqual(0, cube.Y);
-            Assert.AreEqual(0, cube.Z);
+            Assert.AreEqual(0.0, cube.X);
+            Assert.AreEqual(0.0, cube.Y);
+            Assert.AreEqual(0.0, cube.Z);
         }
     }
 }

--- a/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
+++ b/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
@@ -160,14 +160,10 @@ namespace COMETwebapp.Tests.Viewer
             Assert.IsTrue(basicShape is BasicPrimitive);
 
             var basicPrim = basicShape as BasicPrimitive;
-            var orientX = basicPrim.RX;
-            var orientY = basicPrim.RY;
-            var orientZ = basicPrim.RZ;
-            basicPrim.SetOrientationFromElementUsageParameters();
 
-            Assert.AreNotEqual(0.0, basicPrim.RX);
+            Assert.AreEqual(0.0, basicPrim.RX);
             Assert.AreNotEqual(0.0, basicPrim.RY);
-            Assert.AreNotEqual(0.0, basicPrim.RZ);
+            Assert.AreEqual(0.0, basicPrim.RZ);
         }
 
         [Test]

--- a/COMETwebapp/Components/Viewer/SceneProvider.cs
+++ b/COMETwebapp/Components/Viewer/SceneProvider.cs
@@ -109,7 +109,7 @@ namespace COMETwebapp.Components.Viewer
             { LengthShortName, typeof(SimpleQuantityKind) },
             { ThicknessShortName, typeof(SpecializedQuantityKind) },
             { ColorShortName, typeof(TextParameterType) },
-        };
+        };               
 
         /// <summary>
         /// Event for when selection has changed;

--- a/COMETwebapp/Components/Viewer/SceneProvider.cs
+++ b/COMETwebapp/Components/Viewer/SceneProvider.cs
@@ -26,7 +26,6 @@ namespace COMETwebapp.Components.Viewer
 {
     using System;
     using System.Collections.Generic;
-    using System.Drawing;
     using System.Numerics;
     using System.Threading.Tasks;
 
@@ -94,22 +93,7 @@ namespace COMETwebapp.Components.Viewer
         /// <summary>
         /// Collection of the <see cref="Primitive"/> in the Scene
         /// </summary>
-        private static Dictionary<Guid, Primitive> primitivesCollection = new Dictionary<Guid, Primitive>();
-
-        /// <summary>
-        /// Collection for transform from a parameter short name to a parameter type
-        /// </summary>
-        public static Dictionary<string, Type> ParameterShortNameToTypeDictionary = new Dictionary<string, Type>()
-        {
-            { ShapeKindShortName, typeof(EnumerationParameterType) },
-            { OrientationShortName, typeof(ArrayParameterType) },
-            { PositionShortName, typeof(CompoundParameterType) },
-            { WidthShortName, typeof(SpecializedQuantityKind) },
-            { HeightShortName, typeof(SpecializedQuantityKind) },
-            { LengthShortName, typeof(SimpleQuantityKind) },
-            { ThicknessShortName, typeof(SpecializedQuantityKind) },
-            { ColorShortName, typeof(TextParameterType) },
-        };               
+        private static Dictionary<Guid, Primitive> primitivesCollection = new Dictionary<Guid, Primitive>();           
 
         /// <summary>
         /// Event for when selection has changed;

--- a/COMETwebapp/Primitives/BasicPrimitive.cs
+++ b/COMETwebapp/Primitives/BasicPrimitive.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.Primitives
     using COMETwebapp.Components.Viewer;
 
     using COMETwebapp.Utilities;
+    using System.Globalization;
 
     /// <summary>
     /// Class fot primitives that can be positioned and rotated in space
@@ -162,7 +163,7 @@ namespace COMETwebapp.Primitives
         public void SetOrientationFromElementUsageParameters()
         {
             IValueSet? valueSet = this.GetValueSet(SceneProvider.OrientationShortName);
-            var angles = this.ParseIValueToOrientation(valueSet);
+            var angles = this.ParseIValueToEulerAngles(valueSet);
             this.SetRotation(angles[0], angles[1], angles[2]);
         }
 
@@ -210,23 +211,18 @@ namespace COMETwebapp.Primitives
         /// </summary>
         /// <param name="valueSet">the value set to parse</param>
         /// <returns>And array of type [Rx,Ry,Rz]</returns>
-        private double[] ParseIValueToOrientation(IValueSet? valueSet)
+        private double[] ParseIValueToEulerAngles(IValueSet? valueSet)
         {
             double[] angles = new double[3];
 
             if (valueSet is not null)
             {
                 double[] rotMatrix = new double[9];
-                if (valueSet.ActualValue.Any(x => { return (x == "-" || x == string.Empty); }))
+
+                for (int i = 0; i < 9; i++)
                 {
-                    rotMatrix[0] = rotMatrix[4] = rotMatrix[8] = 1.0;
-                }
-                else
-                {
-                    for (int i = 0; i < 9; i++)
-                    {
-                        rotMatrix[i] = double.Parse(valueSet.ActualValue[i]);
-                    }
+                    double.TryParse(valueSet.ActualValue[i], NumberStyles.Any, CultureInfo.InvariantCulture , out double value);
+                    rotMatrix[i] = value;
                 }
 
                 if (rotMatrix.Length == 9)
@@ -255,7 +251,7 @@ namespace COMETwebapp.Primitives
                     break;
 
                 case SceneProvider.OrientationShortName:
-                    var angles = this.ParseIValueToOrientation(newValue);
+                    var angles = this.ParseIValueToEulerAngles(newValue);
                     this.SetRotation(angles[0], angles[1], angles[2]);
                     break;
 

--- a/COMETwebapp/Primitives/Cone.cs
+++ b/COMETwebapp/Primitives/Cone.cs
@@ -119,7 +119,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Cone.cs
+++ b/COMETwebapp/Primitives/Cone.cs
@@ -94,5 +94,32 @@ namespace COMETwebapp.Primitives
                 this.Height = h;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Radius = d/2.0;
+                    }
+                    break;
+                case SceneProvider.HeightShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double h))
+                    {
+                        this.Height = h;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/Cube.cs
+++ b/COMETwebapp/Primitives/Cube.cs
@@ -140,7 +140,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Cube.cs
+++ b/COMETwebapp/Primitives/Cube.cs
@@ -109,5 +109,38 @@ namespace COMETwebapp.Primitives
                 this.Depth = d;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.WidthShortName:
+                    if(double.TryParse(newValue.ActualValue.First(), out double w))
+                    {
+                        this.Width = w;
+                    }
+                    break;
+                case SceneProvider.HeightShortName:
+                    if(double.TryParse(newValue.ActualValue.First(), out double h))
+                    {
+                        this.Height = h;
+                    }
+                    break;
+                case SceneProvider.LengthShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Depth = d;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/Cylinder.cs
+++ b/COMETwebapp/Primitives/Cylinder.cs
@@ -119,7 +119,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Cylinder.cs
+++ b/COMETwebapp/Primitives/Cylinder.cs
@@ -94,5 +94,32 @@ namespace COMETwebapp.Primitives
                 this.Height = h;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Radius = d/2.0;
+                    }
+                    break;
+                case SceneProvider.HeightShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double h))
+                    {
+                        this.Height = h;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/EquilateralTriangle.cs
+++ b/COMETwebapp/Primitives/EquilateralTriangle.cs
@@ -64,5 +64,26 @@ namespace COMETwebapp.Primitives
                 this.Radius = d/2.0;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Radius = d/2.0;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/EquilateralTriangle.cs
+++ b/COMETwebapp/Primitives/EquilateralTriangle.cs
@@ -83,7 +83,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/HexagonalPrism.cs
+++ b/COMETwebapp/Primitives/HexagonalPrism.cs
@@ -77,5 +77,32 @@ namespace COMETwebapp.Primitives
                 this.Height = h;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Radius = d/2.0;
+                    }
+                    break;
+                case SceneProvider.HeightShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double h))
+                    {
+                        this.Height = h;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/HexagonalPrism.cs
+++ b/COMETwebapp/Primitives/HexagonalPrism.cs
@@ -102,7 +102,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -32,6 +32,7 @@ namespace COMETwebapp.Primitives
     using COMETwebapp.Utilities;
     
     using Newtonsoft.Json;
+    using static DevExpress.Utils.HashCodeHelper;
 
     /// <summary>
     /// Represents an <see cref="CDP4Common.EngineeringModelData.ElementUsage"/> on the Scene from the selected <see cref="Option"/> and <see cref="ActualFiniteState"/>
@@ -111,6 +112,13 @@ namespace COMETwebapp.Primitives
         /// ID of the property. Used to identify the primitive between the interop C#-JS
         /// </summary>
         public Guid ID { get; } = Guid.NewGuid();
+
+
+        public void Regen()
+        {
+            string jsonPrimitive = JsonConvert.SerializeObject(this, Formatting.Indented);
+            JSInterop.Invoke("RegenMesh", jsonPrimitive);
+        }
 
         /// <summary>
         /// Sets the color of this <see cref="Primitive"/>.

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -32,7 +32,6 @@ namespace COMETwebapp.Primitives
     using COMETwebapp.Utilities;
     
     using Newtonsoft.Json;
-    using static DevExpress.Utils.HashCodeHelper;
 
     /// <summary>
     /// Represents an <see cref="CDP4Common.EngineeringModelData.ElementUsage"/> on the Scene from the selected <see cref="Option"/> and <see cref="ActualFiniteState"/>
@@ -53,19 +52,19 @@ namespace COMETwebapp.Primitives
         /// The <see cref="ElementUsage"/> for which the <see cref="Primitive"/> was created.
         /// </summary>
         [JsonIgnore]
-        public ElementUsage ElementUsage { get; set; }
+        public ElementUsage ElementUsage { get; set; } = default!;
 
         /// <summary>
         /// The <see cref="Option"/> for which the <see cref="Primitive"/> was created.
         /// </summary>
         [JsonIgnore]
-        public Option SelectedOption { get; set; }
+        public Option SelectedOption { get; set; } = default!;
 
         /// <summary>
         /// The <see cref="ActualFiniteState"/> for which the <see cref="Primitive"/> was created.
         /// </summary>
         [JsonIgnore]
-        public List<ActualFiniteState> States { get; set; }
+        public List<ActualFiniteState> States { get; set; } = default!;
 
         /// <summary>
         /// The default color if the <see cref="Color"/> has not been defined.
@@ -113,7 +112,9 @@ namespace COMETwebapp.Primitives
         /// </summary>
         public Guid ID { get; } = Guid.NewGuid();
 
-
+        /// <summary>
+        /// Regenerates the <see cref="Primitive"/>. This updates the scene with the data of the the <see cref="Primitive"/>
+        /// </summary>
         public void Regen()
         {
             string jsonPrimitive = JsonConvert.SerializeObject(this, Formatting.Indented);

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -115,7 +115,7 @@ namespace COMETwebapp.Primitives
         /// <summary>
         /// Regenerates the <see cref="Primitive"/>. This updates the scene with the data of the the <see cref="Primitive"/>
         /// </summary>
-        public void Regen()
+        public void Regenerate()
         {
             string jsonPrimitive = JsonConvert.SerializeObject(this, Formatting.Indented);
             JSInterop.Invoke("RegenMesh", jsonPrimitive);

--- a/COMETwebapp/Primitives/Rectangle.cs
+++ b/COMETwebapp/Primitives/Rectangle.cs
@@ -100,7 +100,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Rectangle.cs
+++ b/COMETwebapp/Primitives/Rectangle.cs
@@ -75,5 +75,32 @@ namespace COMETwebapp.Primitives
                 this.Height = h;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.WidthShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double w))
+                    {
+                        this.Width = w;
+                    }
+                    break;
+                case SceneProvider.HeightShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double h))
+                    {
+                        this.Height = h;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/ShapeFactory.cs
+++ b/COMETwebapp/Primitives/ShapeFactory.cs
@@ -72,8 +72,10 @@ namespace COMETwebapp.Primitives
         {
             IValueSet? valueSet = null;
             var parameters = elementUsage.GetParametersInUse();
-            Type parameterType = SceneProvider.ParameterShortNameToTypeDictionary[SceneProvider.ShapeKindShortName];
-            var shapeKindParameter = parameters.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.ShapeKindShortName && x.ParameterType.GetType() == parameterType);
+            //Type parameterType = SceneProvider.ParameterShortNameToTypeDictionary[SceneProvider.ShapeKindShortName];
+            //var shapeKindParameter = parameters.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.ShapeKindShortName && x.ParameterType.GetType() == parameterType);
+
+            var shapeKindParameter = parameters.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.ShapeKindShortName, null);
 
             Primitive? primitive = null;
 

--- a/COMETwebapp/Primitives/ShapeFactory.cs
+++ b/COMETwebapp/Primitives/ShapeFactory.cs
@@ -72,9 +72,6 @@ namespace COMETwebapp.Primitives
         {
             IValueSet? valueSet = null;
             var parameters = elementUsage.GetParametersInUse();
-            //Type parameterType = SceneProvider.ParameterShortNameToTypeDictionary[SceneProvider.ShapeKindShortName];
-            //var shapeKindParameter = parameters.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.ShapeKindShortName && x.ParameterType.GetType() == parameterType);
-
             var shapeKindParameter = parameters.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.ShapeKindShortName, null);
 
             Primitive? primitive = null;

--- a/COMETwebapp/Primitives/Sphere.cs
+++ b/COMETwebapp/Primitives/Sphere.cs
@@ -79,5 +79,26 @@ namespace COMETwebapp.Primitives
                 this.Radius =  d/ 2.0;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Radius = d/2.0;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/Sphere.cs
+++ b/COMETwebapp/Primitives/Sphere.cs
@@ -98,7 +98,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Torus.cs
+++ b/COMETwebapp/Primitives/Torus.cs
@@ -119,7 +119,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/Primitives/Torus.cs
+++ b/COMETwebapp/Primitives/Torus.cs
@@ -94,5 +94,32 @@ namespace COMETwebapp.Primitives
                 this.Thickness = t;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Diameter = d;
+                    }
+                    break;
+                case SceneProvider.ThicknessShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double t))
+                    {
+                        this.Thickness = t;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/TriangularPrism.cs
+++ b/COMETwebapp/Primitives/TriangularPrism.cs
@@ -77,5 +77,32 @@ namespace COMETwebapp.Primitives
                 this.Height = h;
             }
         }
+
+        /// <summary>
+        /// Updates a property of the <see cref="Primitive"/> with the data of the <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="parameterTypeShortName">the short name for the parameter type that needs an update</param>
+        /// <param name="newValue">the new value set</param>
+        public override void UpdatePropertyWithParameterData(string parameterTypeShortName, IValueSet newValue)
+        {
+            base.UpdatePropertyWithParameterData(parameterTypeShortName, newValue);
+
+            switch (parameterTypeShortName)
+            {
+                case SceneProvider.DiameterShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double d))
+                    {
+                        this.Radius = d/2.0;
+                    }
+                    break;
+                case SceneProvider.HeightShortName:
+                    if (double.TryParse(newValue.ActualValue.First(), out double h))
+                    {
+                        this.Height = h;
+                    }
+                    break;
+            }
+            this.Regen();
+        }
     }
 }

--- a/COMETwebapp/Primitives/TriangularPrism.cs
+++ b/COMETwebapp/Primitives/TriangularPrism.cs
@@ -102,7 +102,7 @@ namespace COMETwebapp.Primitives
                     }
                     break;
             }
-            this.Regen();
+            this.Regenerate();
         }
     }
 }

--- a/COMETwebapp/wwwroot/Scripts/babylonInterop.js
+++ b/COMETwebapp/wwwroot/Scripts/babylonInterop.js
@@ -415,6 +415,17 @@ function SetMeshVisibility(ID, isVisible) {
 }
 
 /**
+ * Regenerates the mesh asociated to the primitive
+ * @param {object} Primitive - the pritimive to regenerate in JSON string format
+ */
+function RegenMesh(Primitive) {
+    console.log("Regen called");
+    let primitiveJSON = JSON.parse(Primitive);
+    Dispose(primitiveJSON.ID);
+    AddPrimitive(Primitive);
+}
+
+/**
  * Sets the mesh color
  * @param {any} ID - the ID of the primitive to change the color
  * @param {any} r - the red component in range [0,1]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The primitives can now be changed at runtime. 

<!-- Thanks for contributing to COMET-WEB! -->

