### PR TITLE
Properties now can persist on the details panel

### DIFF
--- a/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
+++ b/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
@@ -66,6 +66,8 @@ namespace COMETwebapp.Tests.Viewer
         private IShapeFactory shapeFactory;
         private Option option;
 
+        private double delta = 0.001;
+
         [SetUp]
         public void SetUp()
         {
@@ -167,15 +169,15 @@ namespace COMETwebapp.Tests.Viewer
             Assert.IsTrue(valueSets.Count > 0);
             foreach (var primitive in this.positionables)
             {
-                Assert.AreEqual(0.0, primitive.X);
-                Assert.AreEqual(0.0, primitive.Y);
-                Assert.AreEqual(0.0, primitive.Z);
+                Assert.AreEqual(0.0, primitive.X, delta);
+                Assert.AreEqual(0.0, primitive.Y, delta);
+                Assert.AreEqual(0.0, primitive.Z, delta);
 
                 primitive.SetTranslation(1.0, 1.0, 1.0);
 
-                Assert.AreEqual(1.0, primitive.X);
-                Assert.AreEqual(1.0, primitive.Y);
-                Assert.AreEqual(1.0, primitive.Z);
+                Assert.AreEqual(1.0, primitive.X, delta);
+                Assert.AreEqual(1.0, primitive.Y, delta);
+                Assert.AreEqual(1.0, primitive.Z, delta);
             }
 
         }
@@ -217,19 +219,19 @@ namespace COMETwebapp.Tests.Viewer
         public void VerifyThatTransformationsCanBeReseted()
         {
             var cube = new Cube(1.0, 1.0, 1.0);
-            Assert.AreEqual(0.0, cube.X);
-            Assert.AreEqual(0.0, cube.Y);
-            Assert.AreEqual(0.0, cube.Z);
+            Assert.AreEqual(0.0, cube.X, delta);
+            Assert.AreEqual(0.0, cube.Y, delta);
+            Assert.AreEqual(0.0, cube.Z, delta);
 
             cube.SetTranslation(1.0, 2.0, 3.0);
-            Assert.AreEqual(1.0, cube.X);
-            Assert.AreEqual(2.0, cube.Y);
-            Assert.AreEqual(3.0, cube.Z);
+            Assert.AreEqual(1.0, cube.X, delta);
+            Assert.AreEqual(2.0, cube.Y, delta);
+            Assert.AreEqual(3.0, cube.Z, delta);
 
             cube.ResetTransformations();
-            Assert.AreEqual(0.0, cube.X);
-            Assert.AreEqual(0.0, cube.Y);
-            Assert.AreEqual(0.0, cube.Z);
+            Assert.AreEqual(0.0, cube.X, delta);
+            Assert.AreEqual(0.0, cube.Y, delta);
+            Assert.AreEqual(0.0, cube.Z, delta);
         }
     }
 }

--- a/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
+++ b/COMETwebapp.Tests/Viewer/PrimitivesTests.cs
@@ -29,6 +29,7 @@ namespace COMETwebapp.Tests.Viewer
     using System.Collections.Generic;
     using System.Linq;
     using System.Numerics;
+
     using Bunit;
 
     using CDP4Common.CommonData;
@@ -40,6 +41,7 @@ namespace COMETwebapp.Tests.Viewer
     using COMETwebapp.Primitives;
     using COMETwebapp.SessionManagement;
     using COMETwebapp.Utilities;
+
     using Microsoft.Extensions.DependencyInjection;
 
     using Moq;

--- a/COMETwebapp/Components/PropertiesPanel/DetailsComponent.razor
+++ b/COMETwebapp/Components/PropertiesPanel/DetailsComponent.razor
@@ -20,7 +20,6 @@ Copyright (c) 2022 RHEA System S.A.
     along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @using COMETwebapp.Primitives
-@inherits DetailsComponentBase
 
 @if (this.ParameterSelected.ParameterType is ScalarParameterType scalarType)
 {

--- a/COMETwebapp/Components/PropertiesPanel/DetailsComponent.razor.cs
+++ b/COMETwebapp/Components/PropertiesPanel/DetailsComponent.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="PropertiesBase.cs" company="RHEA System S.A.">
+// <copyright file="DetailsComponent.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
@@ -26,7 +26,7 @@ namespace COMETwebapp.Components.PropertiesPanel
 {
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Types;
-    using COMETwebapp.Components.Viewer;
+
     using COMETwebapp.Primitives;
 
     using Microsoft.AspNetCore.Components;
@@ -34,7 +34,7 @@ namespace COMETwebapp.Components.PropertiesPanel
     /// <summary>
     /// The component used for showing the details of the <see cref="PrimitiveSelected"/>
     /// </summary>
-    public class DetailsComponentBase : ComponentBase
+    public partial class DetailsComponent
     {
         /// <summary>
         /// The collection of <see cref="ParameterBase"/> and <see cref="IValueSet"/> of the <see cref="PrimitiveSelected"/> property
@@ -83,8 +83,6 @@ namespace COMETwebapp.Components.PropertiesPanel
                 }
             }
         }
-
-
 
         /// <summary>
         /// Inits the <see cref="ValueSetsCollection"/>

--- a/COMETwebapp/Components/PropertiesPanel/DetailsComponentBase.cs
+++ b/COMETwebapp/Components/PropertiesPanel/DetailsComponentBase.cs
@@ -26,7 +26,7 @@ namespace COMETwebapp.Components.PropertiesPanel
 {
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Types;
-
+    using COMETwebapp.Components.Viewer;
     using COMETwebapp.Primitives;
 
     using Microsoft.AspNetCore.Components;
@@ -61,7 +61,7 @@ namespace COMETwebapp.Components.PropertiesPanel
             set
             {
                 if (this.primitiveSelected != value)
-                {
+                {                   
                     this.primitiveSelected = value;
                     this.InitValueSet();
                 }
@@ -80,20 +80,11 @@ namespace COMETwebapp.Components.PropertiesPanel
                 if (this.parameterSelected != value)
                 {
                     this.parameterSelected = value;
-                    this.InitValueSet();
                 }
             }
         }
 
-        /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// </summary>
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.InitValueSet();
-        }
+
 
         /// <summary>
         /// Inits the <see cref="ValueSetsCollection"/>

--- a/COMETwebapp/Components/PropertiesPanel/Properties.razor.cs
+++ b/COMETwebapp/Components/PropertiesPanel/Properties.razor.cs
@@ -30,7 +30,7 @@ namespace COMETwebapp.Components.PropertiesPanel
     using CDP4Common.EngineeringModelData;
     
     using CDP4Dal;
-    
+    using COMETwebapp.Components.Viewer;
     using COMETwebapp.IterationServices;
     using COMETwebapp.Primitives;
     using COMETwebapp.SessionManagement;
@@ -57,10 +57,18 @@ namespace COMETwebapp.Components.PropertiesPanel
             get => primitive;
             set
             {
-                primitive = value;
+                primitive = value.Clone();
+                this.ISceneProvider.ClearTemporaryPrimitives();
+                this.ISceneProvider.AddTemporaryPrimitive(this.primitive);
                 this.InitPanelProperties();
             }
         }
+
+        /// <summary>
+        /// The provider of the 3D Scene
+        /// </summary>
+        [Inject]
+        public ISceneProvider ISceneProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the selected <see cref="ParameterBase"/> to fill the details

--- a/COMETwebapp/Components/PropertiesPanel/Properties.razor.cs
+++ b/COMETwebapp/Components/PropertiesPanel/Properties.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="PropertiesBase.cs" company="RHEA System S.A.">
+// <copyright file="Properties.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
@@ -30,6 +30,7 @@ namespace COMETwebapp.Components.PropertiesPanel
     using CDP4Common.EngineeringModelData;
     
     using CDP4Dal;
+
     using COMETwebapp.Components.Viewer;
     using COMETwebapp.IterationServices;
     using COMETwebapp.Primitives;

--- a/COMETwebapp/Components/Viewer/BabylonCanvas.razor.cs
+++ b/COMETwebapp/Components/Viewer/BabylonCanvas.razor.cs
@@ -29,8 +29,6 @@ namespace COMETwebapp.Components.Viewer
     using System.Threading.Tasks;
 
     using CDP4Common.EngineeringModelData;
-
-    using COMETwebapp.Components.Viewer;
     using COMETwebapp.Primitives;
 
     using Microsoft.AspNetCore.Components;
@@ -116,7 +114,7 @@ namespace COMETwebapp.Components.Viewer
         {
             this.IsMouseDown = false;
             //TODO: when the tools are ready here we are going to manage the different types of actions that a user can make.
-
+            await this.SceneProvider.ClearTemporaryPrimitives();
             var primitive = await this.SceneProvider.GetPrimitiveUnderMouseAsync();
             this.SceneProvider.GetPrimitives().ForEach(x => x.IsSelected = false);
             this.SceneProvider.SelectedPrimitive = null;

--- a/COMETwebapp/Components/Viewer/BabylonCanvas.razor.cs
+++ b/COMETwebapp/Components/Viewer/BabylonCanvas.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="BabylonCanvasBase.cs" company="RHEA System S.A.">
+// <copyright file="BabylonCanvas.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar

--- a/COMETwebapp/Components/Viewer/ISceneProvider.cs
+++ b/COMETwebapp/Components/Viewer/ISceneProvider.cs
@@ -116,9 +116,20 @@ namespace COMETwebapp.Components.Viewer
         Task AddPrimitive(Primitive primitive);
 
         /// <summary>
+        /// Adds a temporary primitive to the scene
+        /// </summary>
+        /// <param name="primitive">the primitive to add</param>
+        Task AddTemporaryPrimitive(Primitive primitive);
+
+        /// <summary>
         /// Clears the scene deleting the primitives that contains
         /// </summary>
         Task ClearPrimitives();
+
+        /// <summary>
+        /// Clears the scene deleting the temporary primitives that contains
+        /// </summary>
+        Task ClearTemporaryPrimitives();
 
         /// <summary>
         /// Gets the primitive under the mouse cursor asyncronously

--- a/COMETwebapp/Components/Viewer/SceneProvider.cs
+++ b/COMETwebapp/Components/Viewer/SceneProvider.cs
@@ -97,6 +97,11 @@ namespace COMETwebapp.Components.Viewer
         private static Dictionary<Guid, Primitive> primitivesCollection = new Dictionary<Guid, Primitive>();
 
         /// <summary>
+        /// Collection of temporary <see cref="Primitive"/> in the Scene
+        /// </summary>
+        private static Dictionary<Guid, Primitive> TemporaryPrimitivesCollection = new Dictionary<Guid, Primitive>();
+
+        /// <summary>
         /// Collection for transform from a parameter short name to a parameter type
         /// </summary>
         public static Dictionary<string, Type> ParameterShortNameToTypeDictionary = new Dictionary<string, Type>()
@@ -200,6 +205,21 @@ namespace COMETwebapp.Components.Viewer
         }
 
         /// <summary>
+        /// Adds a temporary primitive to the scene
+        /// </summary>
+        /// <param name="primitive">the primitive to add</param>
+        public async Task AddTemporaryPrimitive(Primitive primitive)
+        {
+            string jsonPrimitive = JsonConvert.SerializeObject(primitive, Formatting.Indented);
+            var color = Color.FromArgb(112,87,255);
+            Vector3 colorVectorized = new Vector3(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f);
+            string jsonColor = JsonConvert.SerializeObject(colorVectorized, Formatting.Indented);
+
+            TemporaryPrimitivesCollection.Add(primitive.ID, primitive);
+            await JSInterop.Invoke("AddPrimitive", jsonPrimitive, jsonColor);
+        }
+
+        /// <summary>
         /// Clears the scene deleting the primitives that contains
         /// </summary>
         public async Task ClearPrimitives()
@@ -210,6 +230,19 @@ namespace COMETwebapp.Components.Viewer
                 await JSInterop.Invoke("Dispose", id);
             }
             primitivesCollection.Clear();
+        }
+
+        /// <summary>
+        /// Clears the scene deleting the temporary primitives that contains
+        /// </summary>
+        public async Task ClearTemporaryPrimitives()
+        {
+            var keys = TemporaryPrimitivesCollection.Keys.ToList();
+            foreach (var id in keys)
+            {
+                await JSInterop.Invoke("Dispose", id);
+            }
+            TemporaryPrimitivesCollection.Clear();
         }
 
         /// <summary>

--- a/COMETwebapp/Pages/Viewer/Viewer.razor.cs
+++ b/COMETwebapp/Pages/Viewer/Viewer.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ViewerBase.cs" company="RHEA System S.A.">
+// <copyright file="Viewer.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar

--- a/COMETwebapp/Pages/Viewer/Viewer.razor.cs
+++ b/COMETwebapp/Pages/Viewer/Viewer.razor.cs
@@ -158,8 +158,7 @@ namespace COMETwebapp.Pages.Viewer
 
                 this.CanvasComponentReference.SceneProvider.OnSelectionChanged += (sender, args) =>
                 {
-                    TreeNode node = null; 
-
+                    TreeNode node = null;
                     if (args.Primitive is not null)
                     {
                         node = this.RootNode.GetFlatListOfDescendants().FirstOrDefault(x => x.Name == args.Primitive.ElementUsage.Name);
@@ -339,6 +338,7 @@ namespace COMETwebapp.Pages.Viewer
         public void TreeSelectionChanged(TreeNode node)
         {
             this.UpdateTreeUI(node);
+            this.CanvasComponentReference.SceneProvider.ClearTemporaryPrimitives();
             var primitivesOnScene = this.CanvasComponentReference.SceneProvider.GetPrimitives();
             primitivesOnScene.ForEach(x => x.IsSelected = false);
 

--- a/COMETwebapp/Primitives/BasicPrimitive.cs
+++ b/COMETwebapp/Primitives/BasicPrimitive.cs
@@ -167,26 +167,6 @@ namespace COMETwebapp.Primitives
         }
 
         /// <summary>
-        /// Get the <see cref="ParameterBase"/> that translates this <see cref="Primitive"/>
-        /// </summary>
-        /// <returns>the related parameter</returns>
-        public ParameterBase? GetTranslationParameter()
-        {
-            var param = this.ElementUsage.GetParametersInUse();
-            return param.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.PositionShortName);
-        }
-
-        /// <summary>
-        /// Get the <see cref="ParameterBase"/> that orients this <see cref="Primitive"/>
-        /// </summary>
-        /// <returns>the related parameter</returns>
-        public ParameterBase? GetOrientationParameter()
-        {
-            var param = this.ElementUsage.GetParametersInUse();
-            return param.FirstOrDefault(x => x.ParameterType.ShortName == SceneProvider.OrientationShortName);
-        }
-
-        /// <summary>
         /// Parses an <see cref="IValueSet"/> to translations along main axes
         /// </summary>
         /// <param name="valueSet">the value set to parse</param>

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -37,7 +37,7 @@ namespace COMETwebapp.Primitives
     /// Represents an <see cref="CDP4Common.EngineeringModelData.ElementUsage"/> on the Scene from the selected <see cref="Option"/> and <see cref="ActualFiniteState"/>
     /// </summary>
     public abstract class Primitive
-    {
+    {        
         /// <summary>
         /// Backing field for the property <see cref="IsSelected"/>
         /// </summary>
@@ -49,10 +49,15 @@ namespace COMETwebapp.Primitives
         private bool isVisible = true;
 
         /// <summary>
+        /// Rendering group of this <see cref="Primitive"/>. Default is 0. Valid Range[0,4].
+        /// </summary>
+        public int RenderingGroup { get; set; } 
+
+        /// <summary>
         /// The <see cref="ElementUsage"/> for which the <see cref="Primitive"/> was created.
         /// </summary>
         [JsonIgnore]
-        public ElementUsage ElementUsage { get; set; }
+        public ElementUsage ElementUsage { get; set; } 
 
         /// <summary>
         /// The <see cref="Option"/> for which the <see cref="Primitive"/> was created.
@@ -239,6 +244,16 @@ namespace COMETwebapp.Primitives
             {
                 this.SetColor(Primitive.DefaultColor);
             }
+        }
+
+        /// <summary>
+        /// Creates a clone of this <see cref="Primitive"/>
+        /// </summary>
+        /// <returns></returns>
+        public Primitive Clone()
+        {
+            var shapeFactory = new ShapeFactory();
+            return shapeFactory.CreatePrimitiveFromElementUsage(this.ElementUsage, this.SelectedOption, this.States)!;
         }
 
         /// <summary>

--- a/COMETwebapp/Primitives/Primitive.cs
+++ b/COMETwebapp/Primitives/Primitive.cs
@@ -207,27 +207,6 @@ namespace COMETwebapp.Primitives
         }
 
         /// <summary>
-        /// Gets a list of the parameters that this <see cref="Primitive"/> contains
-        /// </summary>
-        /// <returns></returns>
-        public List<ParameterBase> GetParameters()
-        {
-            var parameters = new List<ParameterBase>();
-    
-            parameters.AddRange(this.ElementUsage.ParameterOverride);
-
-            this.ElementUsage.ElementDefinition.Parameter.ForEach(x =>
-            {
-                if(!parameters.Any(par=>par.ParameterType.ShortName == x.ParameterType.ShortName))
-                {
-                    parameters.Add(x);
-                }
-            });
-                        
-            return parameters.OrderBy(x=>x.ParameterType.ShortName).ToList();
-        }
-
-        /// <summary>
         /// Set the color of the <see cref="Primitive"/> from the <see cref="ElementUsage"/> parameters
         /// </summary>
         public void SetColorFromElementUsageParameters()

--- a/COMETwebapp/wwwroot/Scripts/babylonInterop.js
+++ b/COMETwebapp/wwwroot/Scripts/babylonInterop.js
@@ -138,7 +138,7 @@ function InitCanvas(canvas) {
         throw "The scene cannot be initialized";
     }
 
-    HighLightLayer = new BABYLON.HighlightLayer("highlightLayer", Scene);
+    HighLightLayer = new BABYLON.HighlightLayer("highlightLayer", Scene, {renderingGroupId:0});
 
     CreateSkybox(Scene, SkyboxSize);
 

--- a/COMETwebapp/wwwroot/Scripts/babylonSpecifics.js
+++ b/COMETwebapp/wwwroot/Scripts/babylonSpecifics.js
@@ -220,6 +220,8 @@ function InitializePrimitiveData(mesh, primitive) {
 
     let babylonMaterial = CreateMaterial(primitiveColor, SceneSpecularColor, SceneEmissiveColor, SceneAmbientColor, "DefaultMaterial", Scene);
     mesh.material = babylonMaterial;
+    mesh.material.useLogarithmicDepth = true;
+    mesh.renderingGroupId = primitive.RenderingGroup;
 
     mesh.actionManager = new BABYLON.ActionManager(Scene);
     RegisterMeshActions(mesh);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The properties now persist on the details panel when another parameter is selected. This makes possible to make all the changes to a primitive and pushed at once. 

<!-- Thanks for contributing to COMET-WEB! -->

