### PR TITLE
Revisions evolution Compound and Array ParameterTypes : Fix #270 #273 

### DIFF
--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
@@ -28,22 +28,22 @@
     {
         <DxToolbar ItemClick="@this.OnItemClick">
             <Items>
-                @for (int i = 1; i < arrayParameterType.Dimension[0] + 1; i++)
+                @for (int dimension = 1; dimension < arrayParameterType.Dimension[0] + 1; dimension++)
                 {
-                    <DxToolbarItem Name="@(i.ToString())" Text="@(i.ToString())" Tooltip="@(i.ToString())" />
+                    <DxToolbarItem Name="@(dimension.ToString())" Text="@(dimension.ToString())" Tooltip="@(dimension.ToString())" />
                 }
             </Items>
         </DxToolbar>
 
         <DxGridLayout CssClass="w-100 ch-480">
             <Rows>
-                @for (int i = 0; i < arrayParameterType.Dimension[1]; i++)
+                @for (int row = 0; row < arrayParameterType.Dimension[1]; row++)
                 {
                     <DxGridLayoutRow Height="auto" />
                 }
             </Rows>
             <Columns>
-                @for (int i = 0; i < arrayParameterType.Dimension[2]; i++)
+                @for (int column = 0; column < arrayParameterType.Dimension[2]; column++)
                 {
                     <DxGridLayoutColumn />
                 }
@@ -77,13 +77,13 @@
     {
         <DxGridLayout CssClass="w-100 ch-480">
             <Rows>
-                @for (int i = 0; i < arrayParameterType.Dimension[0]; i++)
+                @for (int row = 0; row < arrayParameterType.Dimension[0]; row++)
                 {
                     <DxGridLayoutRow Height="auto" />
                 }
             </Rows>
             <Columns>
-                @for (int i = 0; i < arrayParameterType.Dimension[1]; i++)
+                @for (int column = 0; column < arrayParameterType.Dimension[1]; column++)
                 {
                     <DxGridLayoutColumn />
                 }

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
@@ -19,25 +19,9 @@
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
-@using CDP4Common.SiteDirectoryData;
+@using COMETwebapp.Model
 
-@{
-    switch (this.ParameterSubscriptionRow.Parameter.ParameterType)
-    {
-        case BooleanParameterType:
-            <BooleanParameterEvolution ParameterSubscriptionRow="@this.ParameterSubscriptionRow" />
-            break;
-
-        case EnumerationParameterType:
-            <EnumerationParameterEvolution ParameterSubscriptionRow="@this.ParameterSubscriptionRow" />
-            break;
-
-        case CompoundParameterType:
-            <CompoundParameterEvolution ParameterSubscriptionRow="@this.ParameterSubscriptionRow" />
-            break;
-
-        default:
-            <SubscribedParameterEvolution ParameterSubscriptionRow="@this.ParameterSubscriptionRow" />
-            break;
-    }
+@foreach (var parameterSubscription in this.ParameterSubscriptions)
+{
+    <ParameterEvolutionSelector ParameterSubscriptionRow="parameterSubscription" />
 }

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
@@ -19,9 +19,52 @@
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
+@using CDP4Common.SiteDirectoryData;
 @using COMETwebapp.Model
 
-@foreach (var parameterSubscription in this.ParameterSubscriptions)
+@if(this.ParameterSubscriptionRow.Parameter.ParameterType is ArrayParameterType arrayParameterType)
 {
-    <ParameterEvolutionSelector ParameterSubscriptionRow="parameterSubscription" />
+    <DxGridLayout CssClass="w-100 ch-480">
+        <Rows>
+            @for (int i = 0; i < arrayParameterType.Dimension[0]; i++)
+            {
+                <DxGridLayoutRow Height="auto" />
+            }
+        </Rows>
+        <Columns>
+            @for (int i = 0; i < arrayParameterType.Dimension[0]; i++)
+            {
+                <DxGridLayoutColumn />
+            }
+        </Columns>
+        <Items>
+            @for(int n = 0; n < arrayParameterType.Dimension[0]; n++)
+            {
+                @for(int m = 0; m < arrayParameterType.Dimension[1]; m++)
+                {
+                    var index = n * arrayParameterType.Dimension[1] + m;
+                    var x = n;
+                    var y = m;
+                    <DxGridLayoutItem Row="n" Column="m" CssClass="p-30">
+                        <Template>
+                            <div class="gridlayout-header gridlayout-item">
+                                @{
+                                    <div>{@x,@y}</div>
+                                    var parameterSubscription = this.ParameterSubscriptions.ToList()[index];
+                                    <ParameterEvolutionSelector ParameterSubscriptionRow=parameterSubscription />
+                                }
+                            </div>
+                        </Template>
+                    </DxGridLayoutItem>
+                }
+            }
+        </Items>
+    </DxGridLayout>
+}
+else
+{
+    @foreach (var parameterSubscription in this.ParameterSubscriptions)
+    {
+        <ParameterEvolutionSelector ParameterSubscriptionRow="parameterSubscription" />
+    }
 }

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
@@ -28,7 +28,7 @@
     {
         <DxToolbar ItemClick="@this.OnItemClick">
             <Items>
-                @for (int dimension = 1; dimension < arrayParameterType.Dimension[0] + 1; dimension++)
+                @for (var dimension = 1; dimension < arrayParameterType.Dimension[0] + 1; dimension++)
                 {
                     <DxToolbarItem Name="@(dimension.ToString())" Text="@(dimension.ToString())" Tooltip="@(dimension.ToString())" />
                 }
@@ -37,21 +37,21 @@
 
         <DxGridLayout CssClass="w-100 ch-480">
             <Rows>
-                @for (int row = 0; row < arrayParameterType.Dimension[1]; row++)
+                @for (var row = 0; row < arrayParameterType.Dimension[1]; row++)
                 {
                     <DxGridLayoutRow Height="auto" />
                 }
             </Rows>
             <Columns>
-                @for (int column = 0; column < arrayParameterType.Dimension[2]; column++)
+                @for (var column = 0; column < arrayParameterType.Dimension[2]; column++)
                 {
                     <DxGridLayoutColumn />
                 }
             </Columns>
             <Items>
-                @for (int n = 0; n < arrayParameterType.Dimension[1]; n++)
+                @for (var n = 0; n < arrayParameterType.Dimension[1]; n++)
                 {
-                    @for (int m = 0; m < arrayParameterType.Dimension[2]; m++)
+                    @for (var m = 0; m < arrayParameterType.Dimension[2]; m++)
                     {
                         var index = ((int.Parse(selectedDimension) - 1) * (arrayParameterType.Dimension[1] * arrayParameterType.Dimension[2])) + (n * arrayParameterType.Dimension[2]) + m;
                         var x = n + 1;
@@ -77,21 +77,21 @@
     {
         <DxGridLayout CssClass="w-100 ch-480">
             <Rows>
-                @for (int row = 0; row < arrayParameterType.Dimension[0]; row++)
+                @for (var row = 0; row < arrayParameterType.Dimension[0]; row++)
                 {
                     <DxGridLayoutRow Height="auto" />
                 }
             </Rows>
             <Columns>
-                @for (int column = 0; column < arrayParameterType.Dimension[1]; column++)
+                @for (var column = 0; column < arrayParameterType.Dimension[1]; column++)
                 {
                     <DxGridLayoutColumn />
                 }
             </Columns>
             <Items>
-                @for (int n = 0; n < arrayParameterType.Dimension[0]; n++)
+                @for (var n = 0; n < arrayParameterType.Dimension[0]; n++)
                 {
-                    @for (int m = 0; m < arrayParameterType.Dimension[1]; m++)
+                    @for (var m = 0; m < arrayParameterType.Dimension[1]; m++)
                     {
                         var index = n * arrayParameterType.Dimension[1] + m;
                         var x = n;

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor
@@ -24,42 +24,94 @@
 
 @if(this.ParameterSubscriptionRow.Parameter.ParameterType is ArrayParameterType arrayParameterType)
 {
-    <DxGridLayout CssClass="w-100 ch-480">
-        <Rows>
-            @for (int i = 0; i < arrayParameterType.Dimension[0]; i++)
-            {
-                <DxGridLayoutRow Height="auto" />
-            }
-        </Rows>
-        <Columns>
-            @for (int i = 0; i < arrayParameterType.Dimension[0]; i++)
-            {
-                <DxGridLayoutColumn />
-            }
-        </Columns>
-        <Items>
-            @for(int n = 0; n < arrayParameterType.Dimension[0]; n++)
-            {
-                @for(int m = 0; m < arrayParameterType.Dimension[1]; m++)
+    if (arrayParameterType.Dimension.Count > 2)
+    {
+        <DxToolbar ItemClick="@this.OnItemClick">
+            <Items>
+                @for (int i = 1; i < arrayParameterType.Dimension[0] + 1; i++)
                 {
-                    var index = n * arrayParameterType.Dimension[1] + m;
-                    var x = n;
-                    var y = m;
-                    <DxGridLayoutItem Row="n" Column="m" CssClass="p-30">
-                        <Template>
-                            <div class="gridlayout-header gridlayout-item">
-                                @{
-                                    <div>{@x,@y}</div>
-                                    var parameterSubscription = this.ParameterSubscriptions.ToList()[index];
-                                    <ParameterEvolutionSelector ParameterSubscriptionRow=parameterSubscription />
-                                }
-                            </div>
-                        </Template>
-                    </DxGridLayoutItem>
+                    <DxToolbarItem Name="@(i.ToString())" Text="@(i.ToString())" Tooltip="@(i.ToString())" />
                 }
-            }
-        </Items>
-    </DxGridLayout>
+            </Items>
+        </DxToolbar>
+
+        <DxGridLayout CssClass="w-100 ch-480">
+            <Rows>
+                @for (int i = 0; i < arrayParameterType.Dimension[1]; i++)
+                {
+                    <DxGridLayoutRow Height="auto" />
+                }
+            </Rows>
+            <Columns>
+                @for (int i = 0; i < arrayParameterType.Dimension[2]; i++)
+                {
+                    <DxGridLayoutColumn />
+                }
+            </Columns>
+            <Items>
+                @for (int n = 0; n < arrayParameterType.Dimension[1]; n++)
+                {
+                    @for (int m = 0; m < arrayParameterType.Dimension[2]; m++)
+                    {
+                        var index = ((int.Parse(selectedDimension) - 1) * (arrayParameterType.Dimension[1] * arrayParameterType.Dimension[2])) + (n * arrayParameterType.Dimension[2]) + m;
+                        var x = n + 1;
+                        var y = m + 1;
+                        var z = selectedDimension;
+                        <DxGridLayoutItem Row="n" Column="m" CssClass="p-30">
+                            <Template>
+                                <div class="gridlayout-header gridlayout-item">
+                                    @{
+                                        <div>{@z,@x,@y}</div>
+                                        var parameterSubscription = this.ParameterSubscriptions.ToList()[index];
+                                        <ParameterEvolutionSelector ParameterSubscriptionRow=parameterSubscription />
+                                    }
+                                </div>
+                            </Template>
+                        </DxGridLayoutItem>
+                    }
+                }
+            </Items>
+        </DxGridLayout>
+    }
+    else
+    {
+        <DxGridLayout CssClass="w-100 ch-480">
+            <Rows>
+                @for (int i = 0; i < arrayParameterType.Dimension[0]; i++)
+                {
+                    <DxGridLayoutRow Height="auto" />
+                }
+            </Rows>
+            <Columns>
+                @for (int i = 0; i < arrayParameterType.Dimension[1]; i++)
+                {
+                    <DxGridLayoutColumn />
+                }
+            </Columns>
+            <Items>
+                @for (int n = 0; n < arrayParameterType.Dimension[0]; n++)
+                {
+                    @for (int m = 0; m < arrayParameterType.Dimension[1]; m++)
+                    {
+                        var index = n * arrayParameterType.Dimension[1] + m;
+                        var x = n;
+                        var y = m;
+                        <DxGridLayoutItem Row="n" Column="m" CssClass="p-30">
+                            <Template>
+                                <div class="gridlayout-header gridlayout-item">
+                                    @{
+                                        <div>{@x,@y}</div>
+                                        var parameterSubscription = this.ParameterSubscriptions.ToList()[index];
+                                        <ParameterEvolutionSelector ParameterSubscriptionRow=parameterSubscription />
+                                    }
+                                </div>
+                            </Template>
+                        </DxGridLayoutItem>
+                    }
+                }
+            </Items>
+        </DxGridLayout>
+    }
 }
 else
 {

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
@@ -1,0 +1,104 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CompoundParameterEvolution.razor.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023 RHEA System S.A.
+// 
+//     Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.SubscriptionDashboard
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using COMETwebapp.ViewModels.Components.SubscriptionDashboard.Rows;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component that display the evolution of a <see cref="ParameterSubscriptionRowViewModel" /> for a <see cref="CompoundParameterType" />
+    /// </summary>
+    public partial class CompoundParameterEvolution
+    {
+        /// <summary>
+        /// The <see cref="ParameterSubscriptionRowViewModel" /> to display the evolution
+        /// </summary>
+        [Parameter]
+        public ParameterSubscriptionRowViewModel ParameterSubscriptionRow { get; set; }
+
+        /// <summary>
+        /// A collection of <see cref="ParameterSubscriptionRowViewModel" />
+        /// </summary>
+        public IEnumerable<ParameterSubscriptionRowViewModel> ParameterSubscriptions { get; private set; }
+
+        /// <summary>
+        /// Method invoked when the component has received parameters from its parent in
+        /// the render tree, and the incoming values have been assigned to properties.
+        /// </summary>
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            if (this.ParameterSubscriptionRow != null)
+            {
+                this.CreateParameterSubscriptions();
+            }
+        }
+
+        /// <summary>
+        /// Creates parameters subscription
+        /// </summary>
+        private void CreateParameterSubscriptions()
+        {
+            List<ParameterSubscriptionRowViewModel> parameterSubscriptions = new List<ParameterSubscriptionRowViewModel>();
+
+            var compoundParameterType = (CompoundParameterType)this.ParameterSubscriptionRow.Parameter.ParameterType;
+
+            for (var i = 0; i < compoundParameterType.Component.Count; i++)
+            {
+                var parameterType = compoundParameterType.Component[i].ParameterType;
+                var containerParameter = new Parameter()
+                {
+                    Iid = Guid.NewGuid(),
+                    ParameterType = parameterType
+                };
+
+                Dictionary<int, ValueArray<string>> changes = new Dictionary<int, ValueArray<string>>();
+
+                foreach (var kvp in this.ParameterSubscriptionRow.Changes)
+                {
+                    int key = kvp.Key;
+                    var valueArray = new ValueArray<string>(new[] { kvp.Value[i] });
+                    changes.Add(key, valueArray);
+                }
+
+                var parameterSubscriptionViewModel = new ParameterSubscriptionRowViewModel()
+                {
+                    Parameter = containerParameter,
+                    Changes = changes
+                };
+
+                parameterSubscriptions.Add(parameterSubscriptionViewModel);
+            }
+
+            this.ParameterSubscriptions = parameterSubscriptions;
+        }
+    }
+}

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
@@ -74,20 +74,21 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         /// </summary>
         private void CreateParameterSubscriptions()
         {
-            List<ParameterSubscriptionRowViewModel> parameterSubscriptions = new List<ParameterSubscriptionRowViewModel>();
+            var parameterSubscriptions = new List<ParameterSubscriptionRowViewModel>();
 
             var compoundParameterType = (CompoundParameterType)this.ParameterSubscriptionRow.Parameter.ParameterType;
 
             for (var i = 0; i < compoundParameterType.Component.Count; i++)
             {
                 var parameterType = compoundParameterType.Component[i].ParameterType;
+                
                 var containerParameter = new Parameter()
                 {
                     Iid = Guid.NewGuid(),
                     ParameterType = parameterType
                 };
 
-                Dictionary<int, ValueArray<string>> changes = new Dictionary<int, ValueArray<string>>();
+                var changes = new Dictionary<int, ValueArray<string>>();
 
                 foreach (var kvp in this.ParameterSubscriptionRow.Changes)
                 {

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
@@ -92,9 +92,8 @@ namespace COMETwebapp.Components.SubscriptionDashboard
 
                 foreach (var kvp in this.ParameterSubscriptionRow.Changes)
                 {
-                    int key = kvp.Key;
                     var valueArray = new ValueArray<string>(new[] { kvp.Value[parameterTypeComponent] });
-                    changes.Add(key, valueArray);
+                    changes.Add(kvp.Key, valueArray);
                 }
 
                 var parameterSubscriptionViewModel = new ParameterSubscriptionRowViewModel()

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
@@ -78,10 +78,10 @@ namespace COMETwebapp.Components.SubscriptionDashboard
 
             var compoundParameterType = (CompoundParameterType)this.ParameterSubscriptionRow.Parameter.ParameterType;
 
-            for (var i = 0; i < compoundParameterType.Component.Count; i++)
+            for (var parameterTypeComponent = 0; parameterTypeComponent < compoundParameterType.Component.Count; parameterTypeComponent++)
             {
-                var parameterType = compoundParameterType.Component[i].ParameterType;
-                
+                var parameterType = compoundParameterType.Component[parameterTypeComponent].ParameterType;
+
                 var containerParameter = new Parameter()
                 {
                     Iid = Guid.NewGuid(),
@@ -93,7 +93,7 @@ namespace COMETwebapp.Components.SubscriptionDashboard
                 foreach (var kvp in this.ParameterSubscriptionRow.Changes)
                 {
                     int key = kvp.Key;
-                    var valueArray = new ValueArray<string>(new[] { kvp.Value[i] });
+                    var valueArray = new ValueArray<string>(new[] { kvp.Value[parameterTypeComponent] });
                     changes.Add(key, valueArray);
                 }
 

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
@@ -29,7 +29,9 @@ namespace COMETwebapp.Components.SubscriptionDashboard
     using CDP4Common.Types;
 
     using COMETwebapp.ViewModels.Components.SubscriptionDashboard.Rows;
-
+    
+    using DevExpress.Blazor;
+    
     using Microsoft.AspNetCore.Components;
 
     /// <summary>
@@ -42,6 +44,11 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         /// </summary>
         [Parameter]
         public ParameterSubscriptionRowViewModel ParameterSubscriptionRow { get; set; }
+
+        /// <summary>
+        /// The name of selected dimension
+        /// </summary>
+        private string selectedDimension;
 
         /// <summary>
         /// A collection of <see cref="ParameterSubscriptionRowViewModel" />
@@ -99,6 +106,15 @@ namespace COMETwebapp.Components.SubscriptionDashboard
             }
 
             this.ParameterSubscriptions = parameterSubscriptions;
+        }
+
+        /// <summary>
+        /// Method invoked to set the selected dimension from toolbar
+        /// </summary>
+        /// <param name="e"></param>
+        void OnItemClick(ToolbarItemClickEventArgs e)
+        {
+            this.selectedDimension = e.ItemName;
         }
     }
 }

--- a/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/CompoundParameterEvolution.razor.cs
@@ -48,7 +48,7 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         /// <summary>
         /// The name of selected dimension
         /// </summary>
-        private string selectedDimension;
+        private string selectedDimension = "1";
 
         /// <summary>
         /// A collection of <see cref="ParameterSubscriptionRowViewModel" />

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscribedTable.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscribedTable.razor
@@ -26,7 +26,7 @@
 @using CDP4Common.Types
 @inherits DisposableComponent
 
-<DxPopup MaxWidth="1400" MaxHeight="1500" HeaderText="Parameter Subscription Evolution" ShowFooter="false" @ref="@this.parameterEvolutionPopup">
+<DxPopup MaxWidth="1000" MaxHeight="800" HeaderText="Parameter Subscription Evolution" Scrollable=true ShowFooter="false" @ref="@this.parameterEvolutionPopup">
     <ParameterEvolutionSelector ParameterSubscriptionRow="this.parameterSubscriptionRow" />
 </DxPopup>
 

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscribedTable.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscribedTable.razor
@@ -26,7 +26,7 @@
 @using CDP4Common.Types
 @inherits DisposableComponent
 
-<DxPopup MaxWidth="1400" MaxHeight="800" HeaderText="Parameter Subscription Evolution" ShowFooter="false" @ref="@this.parameterEvolutionPopup">
+<DxPopup MaxWidth="1400" MaxHeight="1500" HeaderText="Parameter Subscription Evolution" ShowFooter="false" @ref="@this.parameterEvolutionPopup">
     <ParameterEvolutionSelector ParameterSubscriptionRow="this.parameterSubscriptionRow" />
 </DxPopup>
 

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/Rows/ParameterSubscriptionRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/Rows/ParameterSubscriptionRowViewModel.cs
@@ -70,12 +70,19 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard.Rows
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterSubscriptionRowViewModel" /> class.
+        /// </summary>
+        public ParameterSubscriptionRowViewModel()
+        {
+        }
+
+        /// <summary>
         /// <see cref="Dictionary{TKey,TValue}" /> that reflect changes of the referenced <see cref="ParameterValueSet" />
         /// </summary>
         public Dictionary<int, ValueArray<string>> Changes
         {
             get => this.changes;
-            private set => this.RaiseAndSetIfChanged(ref this.changes, value);
+            set => this.RaiseAndSetIfChanged(ref this.changes, value);
         }
 
         /// <summary>
@@ -124,12 +131,12 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard.Rows
         /// <summary>
         /// The name of the <see cref="ElementBase" />
         /// </summary>
-        public string ElementName => this.Element.Name;
+        public string ElementName => this.Element?.Name;
 
         /// <summary>
         /// The associated <see cref="ParameterOrOverrideBase" />
         /// </summary>
-        public ParameterOrOverrideBase Parameter { get; }
+        public ParameterOrOverrideBase Parameter { get; set; }
 
         /// <summary>
         /// The name of the <see cref="ParameterType" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #270 #273 

Parameter Revision Evolution for CompoundParameterTypes : 
- scrollable 
![Compound](https://user-images.githubusercontent.com/112706228/232042592-1b109350-820f-4443-8a7a-86a820a3b5ab.png)

Parameter Revision Evolution for ArrayParameterTypes : 
- 2D example {2;2} : 
![2D-ARRAY](https://user-images.githubusercontent.com/112706228/232042710-6fcf2c11-9110-4eaf-8895-96b8773ab7d3.png)
- 3D example {3; 2; 2} with tabs to choose wich z coordinate elements to display
![3DARRAY](https://user-images.githubusercontent.com/112706228/232042807-63d05202-8892-4012-be64-e03063944017.png)
![3DARRAY1](https://user-images.githubusercontent.com/112706228/232042831-a26ad244-5169-483a-862f-27a39c503526.png)
![3DARRAY2](https://user-images.githubusercontent.com/112706228/232042842-0b3f1101-e92a-47db-876a-84be93705824.png)

<!-- Thanks for contributing to COMET-WEB! -->