### PR TITLE
Path to resources due to change of PackageId & reference nuget Fix#338

### DIFF
--- a/COMET.Web.Common/Pages/Index.razor
+++ b/COMET.Web.Common/Pages/Index.razor
@@ -20,6 +20,7 @@
 //   limitations under the License.
 ------------------------------------------------------------------------------->
 @page "/"
+@using COMET.Web.Common.Utilities
 @inherits DisposableComponent
 
 <AuthorizeView>
@@ -50,7 +51,7 @@
 	<NotAuthorized>
 		<div class="container height-90">
 		<div class="row justify-content-center">
-			<img id="comet-logo" src="_content/COMET.WEB.Common/images/COMET-Logo-large.png" class="p-1 large-logo" title="COMET Community Edition" alt="COMET Community Edition"/>
+				<img id="comet-logo" src=@ContentPathBuilder.BuildPath("images/COMET-Logo-large.png") class="p-1 large-logo" title="COMET Community Edition" alt="COMET Community Edition" />
 		</div>
 		<div class="comet-info row text-align-center justify-content-center">
 			<div class="card width-70">

--- a/COMET.Web.Common/Shared/TopMenuEntry/TopMenuTitle.razor
+++ b/COMET.Web.Common/Shared/TopMenuEntry/TopMenuTitle.razor
@@ -19,9 +19,11 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 ------------------------------------------------------------------------------->
+@using COMET.Web.Common.Utilities
+
 <div class="display-flex align-items-center">
 	<a class="homelink" href="/">
-		<img src="_content/COMET.WEB.Common/images/COMET-Symbol.png" class="logo-size p-1" title="COMET Community Edition" alt="COMET Community Edition"/>
+		<img src=@ContentPathBuilder.BuildPath("images/COMET-Symbol.png") class="logo-size p-1" title="COMET Community Edition" alt="COMET Community Edition" />
 		<div class="font-weight-bold title title-item">COMET Community Edition</div>
 	</a>
 </div>

--- a/COMET.Web.Common/Utilities/ContentPathBuilder.cs
+++ b/COMET.Web.Common/Utilities/ContentPathBuilder.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ContentPathBuilder.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023 RHEA System S.A.
+// 
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+// 
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Utilities
+{
+    /// <summary>
+    /// Utility class that enables to create path for content inside the assembly
+    /// </summary>
+    internal static class ContentPathBuilder
+    {
+        /// <summary>
+        /// The name of the Nuget PackageId
+        /// </summary>
+        internal const string PackageId = "CDP4.WEB.Common";
+
+        /// <summary>
+        /// Builds the path to access a content inside the assembly
+        /// </summary>
+        /// <param name="pathOfContent">A relative path to access the content</param>
+        /// <returns>The full builded path</returns>
+        internal static string BuildPath(string pathOfContent)
+        {
+            return Path.Combine("_content", PackageId, pathOfContent);
+        }
+    }
+}

--- a/COMETwebapp/COMETwebapp.csproj
+++ b/COMETwebapp/COMETwebapp.csproj
@@ -74,14 +74,11 @@
     <ItemGroup>
         <PackageReference Include="AntDesign" Version="0.14.1" />
         <PackageReference Include="BlazorStrap" Version="5.1.100" />
+        <PackageReference Include="CDP4.WEB.Common" Version="1.0.1" />
         <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
         <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.4" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.4" PrivateAssets="all" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\COMET.Web.Common\COMET.Web.Common.csproj" />
     </ItemGroup>
 
 </Project>

--- a/COMETwebapp/Dockerfile
+++ b/COMETwebapp/Dockerfile
@@ -2,7 +2,6 @@
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 
-COPY COMET.Web.Common COMET.Web.Common
 COPY COMETwebapp COMETwebapp
 
 RUN --mount=type=secret,id=DEVEXPRESS_NUGET_KEY export DEVEXPRESS_NUGET_KEY=$(cat /run/secrets/DEVEXPRESS_NUGET_KEY) \ 

--- a/COMETwebapp/wwwroot/index.html
+++ b/COMETwebapp/wwwroot/index.html
@@ -9,7 +9,7 @@
     <link href="COMETwebapp.styles.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="_content/AntDesign/css/ant-design-blazor.css" rel="stylesheet" />
-    <link href="_content/COMET.Web.Common/css/styles.css" rel="stylesheet" />
+    <link href="_content/CDP4.WEB.Common/css/styles.css" rel="stylesheet" />
     <link href="_content/DevExpress.Blazor.Themes/bootstrap-external.bs5.min.css" rel="stylesheet" />
 
     <style type="text/css">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #338 

Since PackageId of the Common library changed, references to internal content had to be updated.
For docker build, it requires to reference the nuget package instead of a ProjectReference to access css/internal content
<!-- Thanks for contributing to COMET-WEB! -->

