### PR TITLE
HaveObjectChangedTracking base class implemented: Fix #366

### DIFF
--- a/COMET.Web.Common.Tests/Utilities/HaveObjectChangedTracking/HaveObjectChangedTrackingTestFixture.cs
+++ b/COMET.Web.Common.Tests/Utilities/HaveObjectChangedTracking/HaveObjectChangedTrackingTestFixture.cs
@@ -1,0 +1,122 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="HaveObjectChangedTrackingTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023 RHEA System S.A.
+// 
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+// 
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Utilities.HaveObjectChangedTracking
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using COMET.Web.Common.Utilities.HaveObjectChangedTracking;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class HaveObjectChangedTrackingTestFixture
+    {
+        private class ObjectChangedTracking: HaveObjectChangedTracking
+        {
+            public IReadOnlyList<Thing> AddedThingsReadOnlyList => this.AddedThings.AsReadOnly();
+
+            public IReadOnlyList<Thing> DeletedThingsReadOnlyList => this.DeletedThings.AsReadOnly();
+
+            public IReadOnlyList<Thing> UpdatedThingsReadOnlyList => this.UpdatedThings.AsReadOnly();
+
+            public void Initialize(IEnumerable<Type> types)
+            {
+                this.InitializeSubscriptions(types);
+            }
+
+            public void Clear()
+            {
+                this.ClearRecordedChanges();
+            }
+        }
+
+        [Test]
+        public void VerifyCollectionsAfterObjectChangeEvent()
+        {
+            var objectChangedTracking = new ObjectChangedTracking();
+            var elementDefinition = new ElementDefinition();
+
+            CDPMessageBus.Current.SendObjectChangeEvent(elementDefinition, EventKind.Added);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(objectChangedTracking.AddedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+            });
+
+            objectChangedTracking.Initialize(new List<Type> { typeof(ElementBase)});
+            CDPMessageBus.Current.SendObjectChangeEvent(elementDefinition, EventKind.Added);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(objectChangedTracking.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
+                Assert.That(objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+            });
+
+            CDPMessageBus.Current.SendObjectChangeEvent(elementDefinition, EventKind.Updated);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(objectChangedTracking.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
+                Assert.That(objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.UpdatedThingsReadOnlyList, Has.Count.EqualTo(1));
+            });
+
+            CDPMessageBus.Current.SendObjectChangeEvent(elementDefinition, EventKind.Removed);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(objectChangedTracking.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
+                Assert.That(objectChangedTracking.DeletedThingsReadOnlyList, Has.Count.EqualTo(1));
+                Assert.That(objectChangedTracking.UpdatedThingsReadOnlyList, Has.Count.EqualTo(1));
+            });
+
+            objectChangedTracking.Clear();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(objectChangedTracking.AddedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+            });
+
+            CDPMessageBus.Current.SendObjectChangeEvent(new Parameter(), EventKind.Removed);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(objectChangedTracking.AddedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
+                Assert.That(objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+            });
+        }
+    }
+}

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -42,5 +42,4 @@
         <InternalsVisibleTo Include="COMET.Web.Common.Tests" />
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
-
 </Project>

--- a/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
+++ b/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
@@ -1,0 +1,102 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="HaveObjectChangedTracking.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023 RHEA System S.A.
+// 
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+// 
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Utilities.HaveObjectChangedTracking
+{
+    using System.Reactive.Linq;
+
+    using CDP4Common.CommonData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using COMET.Web.Common.Utilities.DisposableObject;
+
+    /// <summary>
+    /// Base class for any class that needs to track <see cref="ObjectChangedEvent" /> for one or multiple types
+    /// </summary>
+    public abstract class HaveObjectChangedTracking : DisposableObject
+    {
+        /// <summary>
+        /// A collection of added <see cref="Thing" />s
+        /// </summary>
+        protected readonly List<Thing> AddedThings = new();
+
+        /// <summary>
+        /// A collection of deleted <see cref="Thing" />s
+        /// </summary>
+        protected readonly List<Thing> DeletedThings = new();
+
+        /// <summary>
+        /// A collection of updated <see cref="Thing" />s
+        /// </summary>
+        protected readonly List<Thing> UpdatedThings = new();
+
+        /// <summary>
+        /// Initializes all <see cref="ObjectChangedEvent" /> subscription
+        /// </summary>
+        /// <param name="typesOfInterest">
+        /// A collection of <see cref="Type" /> to create <see cref="ObjectChangedEvent" />
+        /// subscriptions
+        /// </param>
+        protected void InitializeSubscriptions(IEnumerable<Type> typesOfInterest)
+        {
+            var observables = typesOfInterest.Select(objectChangedTypeTarget => CDPMessageBus.Current.Listen<ObjectChangedEvent>(objectChangedTypeTarget)).ToList();
+            this.Disposables.Add(observables.Merge().Subscribe(this.RecordChange));
+        }
+
+        /// <summary>
+        /// Clears all recorded changes
+        /// </summary>
+        protected void ClearRecordedChanges()
+        {
+            this.DeletedThings.Clear();
+            this.UpdatedThings.Clear();
+            this.AddedThings.Clear();
+        }
+
+        /// <summary>
+        /// Records an <see cref="ObjectChangedEvent" />
+        /// </summary>
+        /// <param name="objectChangedEvent">The <see cref="ObjectChangedEvent" /></param>
+        protected virtual void RecordChange(ObjectChangedEvent objectChangedEvent)
+        {
+            switch (objectChangedEvent.EventKind)
+            {
+                case EventKind.Added:
+                    this.AddedThings.Add(objectChangedEvent.ChangedThing);
+                    break;
+                case EventKind.Removed:
+                    this.DeletedThings.Add(objectChangedEvent.ChangedThing);
+                    break;
+                case EventKind.Updated:
+                    this.UpdatedThings.Add(objectChangedEvent.ChangedThing);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(objectChangedEvent), "Unrecognised value EventKind value");
+            }
+        }
+    }
+}

--- a/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
+++ b/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
@@ -63,6 +63,7 @@ namespace COMET.Web.Common.Utilities.HaveObjectChangedTracking
         /// </param>
         protected void InitializeSubscriptions(IEnumerable<Type> typesOfInterest)
         {
+            this.Dispose();
             var observables = typesOfInterest.Select(objectChangedTypeTarget => CDPMessageBus.Current.Listen<ObjectChangedEvent>(objectChangedTypeTarget)).ToList();
             this.Disposables.Add(observables.Merge().Subscribe(this.RecordChange));
         }

--- a/COMET.Web.Common/ViewModels/Components/SingleIterationApplicationBaseViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/SingleIterationApplicationBaseViewModel.cs
@@ -35,7 +35,7 @@ namespace COMET.Web.Common.ViewModels.Components
 
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Services.SessionManagement;
-    using COMET.Web.Common.Utilities.DisposableObject;
+    using COMET.Web.Common.Utilities.HaveObjectChangedTracking;
 
     using DynamicData.Binding;
 
@@ -44,7 +44,7 @@ namespace COMET.Web.Common.ViewModels.Components
     /// <summary>
     /// Base view model for any application that will need only one <see cref="Iteration" />
     /// </summary>
-    public abstract class SingleIterationApplicationBaseViewModel : DisposableObject, ISingleIterationApplicationBaseViewModel
+    public abstract class SingleIterationApplicationBaseViewModel : HaveObjectChangedTracking, ISingleIterationApplicationBaseViewModel
     {
         /// <summary>
         /// Backing field for <see cref="CurrentIteration" />
@@ -106,6 +106,20 @@ namespace COMET.Web.Common.ViewModels.Components
         /// Value asserting that the view model has set initial values at least once
         /// </summary>
         public bool HasSetInitialValuesOnce { get; set; }
+
+        /// <summary>
+        /// Records an <see cref="ObjectChangedEvent" />
+        /// </summary>
+        /// <param name="objectChangedEvent">The <see cref="ObjectChangedEvent" /></param>
+        protected override void RecordChange(ObjectChangedEvent objectChangedEvent)
+        {
+            if (this.CurrentIteration == null || objectChangedEvent.ChangedThing.GetContainerOfType<Iteration>().Iid != this.CurrentIteration.Iid)
+            {
+                return;
+            }
+
+            base.RecordChange(objectChangedEvent);
+        }
 
         /// <summary>
         /// Handles the refresh of the current <see cref="ISession" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #366 

HaveObjectChangedTracking handles subcriptions for ObjectChangeEvent for specific types
<!-- Thanks for contributing to COMET-WEB! -->

