### PR TITLE
Build tree with all element usage : Fix #354

### DIFF
--- a/COMETwebapp/Model/SystemNode.cs
+++ b/COMETwebapp/Model/SystemNode.cs
@@ -87,7 +87,7 @@ namespace COMETwebapp.Model
         /// <returns>the childrens of the node</returns>
         public IReadOnlyList<SystemNode> GetChildren()
         {
-            return this.Children.AsReadOnly();
+            return this.Children.OrderBy(node => node.Title).ToList().AsReadOnly();
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
@@ -191,8 +191,8 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         {
             var childsOfElementBase = elementBase switch
             {
-                ElementDefinition elementDefinition => this.CurrentDomain != null ? elementDefinition.ContainedElement.Where(e => e.Owner == this.CurrentDomain).ToList() : elementDefinition.ContainedElement,
-                ElementUsage elementUsage => this.CurrentDomain != null ? elementUsage.ElementDefinition.ContainedElement.Where(e => e.Owner == this.CurrentDomain).ToList() : elementUsage.ElementDefinition.ContainedElement,
+                ElementDefinition elementDefinition =>  elementDefinition.ContainedElement,
+                ElementUsage elementUsage => elementUsage.ElementDefinition.ContainedElement,
                 _ => null
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #354 

System representation tree is built with all element usage
<!-- Thanks for contributing to COMET-WEB! -->

