### PR TITLE
Remove parameterType name from TextParameterTypeEditor :  Fix #377

### DIFF
--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -40,7 +40,6 @@
     else
     {
         <div class="parameter-row">
-            <p class="orientation_p">@this.ViewModel.ParameterType.Name</p>
             <DxTextBox InputCssClass="text-parameter-type"
                        Text="@this.ViewModel.ValueArray.First()"
                        CssClass="parameter-input"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #377 

ParameterType name removed from TextParameterTypeEditor to make more room for the input

<!-- Thanks for contributing to COMET-WEB! -->

