### PR TITLE
Feat/make open model configurable

### DIFF
--- a/COMET.Web.Common.Tests/Components/DashboardTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/DashboardTestFixture.cs
@@ -32,7 +32,9 @@ namespace COMET.Web.Common.Tests.Components
     using Bunit;
 
     using COMET.Web.Common.Components;
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Model;
+    using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.RegistrationService;
 
     using Microsoft.AspNetCore.Components;
@@ -49,6 +51,7 @@ namespace COMET.Web.Common.Tests.Components
     {
         private List<Application> applications;
         private Mock<IRegistrationService> registrationService;
+        private Mock<IConfigurationService> configurationService;
         private TestContext context;
 
         [SetUp]
@@ -80,8 +83,12 @@ namespace COMET.Web.Common.Tests.Components
             this.registrationService.Setup(x => x.RegisteredApplications)
                 .Returns(this.applications);
 
+            this.configurationService = new Mock<IConfigurationService>();
+            this.configurationService.Setup(x => x.GetText(TextConfigurationKind.LandingPageTitle)).Returns(string.Empty);
+
             this.context = new TestContext();
             this.context.Services.AddSingleton(this.registrationService.Object);
+            this.context.Services.AddSingleton(this.configurationService.Object);
         }
 
         [TearDown]

--- a/COMET.Web.Common.Tests/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
+++ b/COMET.Web.Common.Tests/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
@@ -29,6 +29,7 @@ namespace COMET.Web.Common.Tests.Services.ConfigurationService
     using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.ConfigurationService;
 
+    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
 
     using Moq;
@@ -81,7 +82,8 @@ namespace COMET.Web.Common.Tests.Services.ConfigurationService
                 BaseAddress = new Uri("http://localhost")
             };
 
-            this.configurationService = new ConfigurationService(options.Object, httpClient);
+            var loggerMock = new Mock<ILogger<ConfigurationService>>();
+            this.configurationService = new ConfigurationService(options.Object, httpClient, loggerMock.Object);
         }
 
         [Test]

--- a/COMET.Web.Common.Tests/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
+++ b/COMET.Web.Common.Tests/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
@@ -26,6 +26,7 @@ namespace COMET.Web.Common.Tests.Services.ConfigurationService
 {
     using System.Net;
 
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.ConfigurationService;
 
@@ -42,14 +43,14 @@ namespace COMET.Web.Common.Tests.Services.ConfigurationService
     {
         private IConfigurationService configurationService;
 
-        [SetUp]
-        public void SetUp()
+        [Test]
+        public async Task VerifyService()
         {
             var globalOptions = new GlobalOptions
             {
                 JsonConfigurationFile = null,
             };
-            
+
             var options = new Mock<IOptions<GlobalOptions>>();
             options.Setup(x => x.Value).Returns(globalOptions);
 
@@ -59,11 +60,15 @@ namespace COMET.Web.Common.Tests.Services.ConfigurationService
                         {
                             "OpenEngineeringModelPlaceholder": "Select an Engineering Model",
                             "OpenIterationPlaceholder": "Select an Iteration",
-                            "OpenDomainOfExpertisePlaceholder": "Select a Domain of Expertise"
+                            "OpenDomainOfExpertisePlaceholder": "Select a Domain of Expertise",
+                            "ModelTitleCaption" : "Model",
+                            "IterationTitleCaption" : "Iteration",
+                            "DomainTitleCaption" : "Domain",
+                            "LandingPageTitle" : ""
                         }
                         """;
-            
-			handlerMock
+
+            handlerMock
                 .Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
@@ -84,23 +89,83 @@ namespace COMET.Web.Common.Tests.Services.ConfigurationService
 
             var loggerMock = new Mock<ILogger<ConfigurationService>>();
             this.configurationService = new ConfigurationService(options.Object, httpClient, loggerMock.Object);
-        }
 
-        [Test]
-        public void VerifyService()
-        {
             Assert.Multiple(() =>
             {
                 Assert.That(this.configurationService, Is.Not.Null);
                 Assert.Throws<InvalidOperationException>(()=>this.configurationService.GetText(""));
             });
 
-            this.configurationService.InitializeService();
+            await this.configurationService.InitializeService();
 
             Assert.Multiple(() =>
             {
                 Assert.DoesNotThrow(() => this.configurationService.GetText(""));
-                Assert.That(this.configurationService.GetText("OpenEngineeringModelPlaceholder"), Is.EqualTo("Select an Engineering Model"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.OpenEngineeringModelPlaceholder), Is.EqualTo("Select an Engineering Model"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.OpenIterationPlaceholder), Is.EqualTo("Select an Iteration"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.OpenDomainOfExpertisePlaceholder), Is.EqualTo("Select a Domain of Expertise"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.ModelTitleCaption), Is.EqualTo("Model"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.IterationTitleCaption), Is.EqualTo("Iteration"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.DomainTitleCaption), Is.EqualTo("Domain"));
+                Assert.That(this.configurationService.GetText(TextConfigurationKind.LandingPageTitle), Is.EqualTo(""));
+                Assert.That(this.configurationService.GetConfigurations(), Is.Not.Null);
+                Assert.That(this.configurationService.GetConfigurations(), Is.Not.Empty);
+            });
+        }
+
+        [Test]
+        public async Task VerifyExceptionIsNotThrown()
+        {
+            var globalOptions = new GlobalOptions
+            {
+                JsonConfigurationFile = null,
+            };
+
+            var options = new Mock<IOptions<GlobalOptions>>();
+            options.Setup(x => x.Value).Returns(globalOptions);
+
+            var handlerMock = new Mock<HttpMessageHandler>();
+
+            var Invalidjson = """ 
+                        {
+                            "OpenEngineeringModelPlaceholder": "Select an Engineering Model",
+                            "OpenIterationPlaceholder": "Select an Iteration",
+                            "OpenDomainOfExpertisePlaceholder": "Select a Domain of Expertise",
+                            "ModelTitleCaption" : "Model",
+                            "IterationTitleCaption" : "Iteration",
+                            "DomainTitleCaption" : "Domain",
+                            "LandingPageTitle" : 1
+                        }
+                        """;
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(Invalidjson)
+                })
+                .Verifiable();
+
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+
+            var loggerMock = new Mock<ILogger<ConfigurationService>>();
+            this.configurationService = new ConfigurationService(options.Object, httpClient, loggerMock.Object);
+
+            await this.configurationService.InitializeService();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.configurationService.GetConfigurations(), Is.Not.Null);
+                Assert.That(this.configurationService.GetConfigurations(), Is.Empty);
             });
         }
 	}

--- a/COMET.Web.Common/Components/Dashboard.razor
+++ b/COMET.Web.Common/Components/Dashboard.razor
@@ -19,12 +19,15 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 ------------------------------------------------------------------------------->
+
+@using COMET.Web.Common.Enumerations
 @namespace COMET.Web.Common.Components
 <div id="dashboard" class="container-fluid dashboard">
-	<div class="row justify-content-center dashboard__cards">
-		@foreach(var application in this.RegistrationService.RegisteredApplications)
-		{
-			<ApplicationCard CurrentApplication="application" />
-		}
-	</div>
+    <h3 id="dashboard-title">@(this.ConfigurationService.GetText(TextConfigurationKind.LandingPageTitle))</h3>
+    <div class="row justify-content-center dashboard__cards">
+        @foreach (var application in this.RegistrationService.RegisteredApplications)
+        {
+            <ApplicationCard CurrentApplication="application"/>
+        }
+    </div>
 </div>

--- a/COMET.Web.Common/Components/Dashboard.razor.cs
+++ b/COMET.Web.Common/Components/Dashboard.razor.cs
@@ -26,6 +26,7 @@
 namespace COMET.Web.Common.Components
 {
     using COMET.Web.Common.Model;
+    using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.RegistrationService;
 
     using Microsoft.AspNetCore.Components;
@@ -40,5 +41,11 @@ namespace COMET.Web.Common.Components
         /// </summary>
         [Inject]
         internal IRegistrationService RegistrationService { get; set; }
+
+        /// <summary>
+        /// The <see cref="IConfigurationService"/>
+        /// </summary>
+        [Inject]
+        public IConfigurationService ConfigurationService { get; set; }
     }
 }

--- a/COMET.Web.Common/Components/Dashboard.razor.css
+++ b/COMET.Web.Common/Components/Dashboard.razor.css
@@ -1,0 +1,3 @@
+﻿#dashboard-title{
+    text-align:center;
+}

--- a/COMET.Web.Common/Components/OpenModel.razor
+++ b/COMET.Web.Common/Components/OpenModel.razor
@@ -27,7 +27,7 @@
 @inherits DisposableComponent
 
 <DxFormLayout CaptionPosition="CaptionPosition.Vertical">
-	<DxFormLayoutItem Caption="Model:" ColSpanLg="12">
+	<DxFormLayoutItem Caption="@(this.ConfigurationService.GetText(TextConfigurationKind.ModelTitleCaption))" ColSpanLg="12">
 		<Template>
 			<DxComboBox Id="model-selection" Data="@this.ViewModel.AvailableEngineeringModelSetups"
 			            TextFieldName="@nameof(EngineeringModelSetup.Name)"
@@ -38,7 +38,7 @@
 	</DxFormLayoutItem>
 	@if (this.ViewModel.SelectedEngineeringModel != null)
 	{
-		<DxFormLayoutItem Caption="Iteration:" ColSpanLg="12">
+		<DxFormLayoutItem Caption="@(this.ConfigurationService.GetText(TextConfigurationKind.IterationTitleCaption))" ColSpanLg="12">
 			<Template>
 				<DxComboBox Id="iteration-selection" Data="@this.ViewModel.AvailableIterationSetups"
 				            TextFieldName="@nameof(IterationData.IterationName)"
@@ -47,7 +47,7 @@
 							Enabled="@this.selectorEnabled" />
 			</Template>
 		</DxFormLayoutItem>
-		<DxFormLayoutItem Caption="Domain:" ColSpanLg="12">
+		<DxFormLayoutItem Caption="@(this.ConfigurationService.GetText(TextConfigurationKind.DomainTitleCaption))" ColSpanLg="12">
 			<Template>
 				<DxComboBox Id="domain-selection" Data="@this.ViewModel.AvailablesDomainOfExpertises"
 				            TextFieldName="@nameof(DomainOfExpertise.Name)"

--- a/COMET.Web.Common/Enumerations/TextConfigurationKind.cs
+++ b/COMET.Web.Common/Enumerations/TextConfigurationKind.cs
@@ -44,5 +44,25 @@ namespace COMET.Web.Common.Enumerations
         /// Placeholder for the combobox to select a DomainOfExpertise
         /// </summary>
         OpenDomainOfExpertisePlaceholder = 2,
+
+        /// <summary>
+        /// The caption to use as title for the model section
+        /// </summary>
+        ModelTitleCaption = 3,
+
+        /// <summary>
+        /// The caption to use as title for the iteration section
+        /// </summary>
+        IterationTitleCaption = 4,
+
+        /// <summary>
+        /// The caption to use as title for the domain section
+        /// </summary>
+        DomainTitleCaption = 5,
+
+        /// <summary>
+        /// The title to use in the landing page
+        /// </summary>
+        LandingPageTitle = 6
     }
 }

--- a/COMET.Web.Common/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/ConfigurationService.cs
@@ -51,7 +51,7 @@ namespace COMET.Web.Common.Services.ConfigurationService
         /// <summary>
         /// The <see cref="ILogger{T}"/>
         /// </summary>
-        private ILogger<ConfigurationService> logger;
+        private readonly ILogger<ConfigurationService> logger;
 
         /// <summary>
         /// The dictionary that contains the map between the configuration and the value
@@ -126,6 +126,15 @@ namespace COMET.Web.Common.Services.ConfigurationService
         public string GetText(TextConfigurationKind configurationKind)
         {
             return this.GetText(configurationKind.ToString());
+        }
+
+        /// <summary>
+        /// Gets the configurations of the <see cref="ConfigurationService"/>
+        /// </summary>
+        /// <returns>a dictionary with the configurations</returns>
+        public Dictionary<string, string> GetConfigurations()
+        {
+            return this.configurations;
         }
     }
 }

--- a/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
@@ -51,5 +51,11 @@ namespace COMET.Web.Common.Services.ConfigurationService
         /// <param name="configurationKind">the <see cref="TextConfigurationKind"/> key</param>
         /// <returns>the text asociated to the key</returns>
         string GetText(TextConfigurationKind configurationKind);
+
+        /// <summary>
+        /// Gets the configurations of the <see cref="ConfigurationService"/>
+        /// </summary>
+        /// <returns>a dictionary with the configurations</returns>
+        Dictionary<string, string> GetConfigurations();
     }
 }

--- a/COMET.Web.Common/wwwroot/DefaultTextConfiguration.json
+++ b/COMET.Web.Common/wwwroot/DefaultTextConfiguration.json
@@ -5,5 +5,5 @@
   "ModelTitleCaption": "Model",
   "IterationTitleCaption": "Iteration",
   "DomainTitleCaption": "Domain",
-  "LandingPageTitle" : "This is a test" 
+  "LandingPageTitle" : "" 
 }

--- a/COMET.Web.Common/wwwroot/DefaultTextConfiguration.json
+++ b/COMET.Web.Common/wwwroot/DefaultTextConfiguration.json
@@ -1,5 +1,9 @@
 {
   "OpenEngineeringModelPlaceholder": "Select an Engineering Model",
   "OpenIterationPlaceholder": "Select an Iteration",
-  "OpenDomainOfExpertisePlaceholder": "Select a Domain of Expertise"
+  "OpenDomainOfExpertisePlaceholder": "Select a Domain of Expertise",
+  "ModelTitleCaption": "Model",
+  "IterationTitleCaption": "Iteration",
+  "DomainTitleCaption": "Domain",
+  "LandingPageTitle" : "This is a test" 
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The configuration service now contains more values so the OpenModel component captions can be configured. Also the landing page can add a title.

