### PR TITLE
Element definition creation improvements : Fix #389

### DIFF
--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
@@ -130,7 +130,7 @@
                         </DxFormLayoutItem>
                     </DxFormLayoutTabPage>
                     <DxFormLayoutTabPage Caption="Category">
-                        <DxListBox Data="@this.ViewModel.AvailableCategories"
+                        <DxListBox Data="@this.ViewModel.AvailableCategories.OrderBy(x => x.Name)"
                         @bind-Values="@this.ViewModel.SelectedCategories"
                                    SelectionMode="ListBoxSelectionMode.Multiple"
                                    TextFieldName="@nameof(Category.Name)"

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
@@ -448,7 +448,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         {
             foreach (var referenceDataLibrary in this.sessionService.Session.RetrieveSiteDirectory().AvailableReferenceDataLibraries())
             {
-                this.AvailableCategories = this.AvailableCategories.Concat(referenceDataLibrary.DefinedCategory);
+                this.AvailableCategories = this.AvailableCategories.Concat(referenceDataLibrary.DefinedCategory).Where(category => category.PermissibleClass.Contains(ClassKind.ElementDefinition)).ToList();
             }
 
             this.AvailableDomains = this.sessionService.Session.RetrieveSiteDirectory().Domain;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #389 

In ElementDefinition Creation component :
- Categories are ordered by Name,
-  All Categories where the PermissibleClasses does not contains ED are removed

<!-- Thanks for contributing to COMET-WEB! -->

