### PR TITLE
Multiline editor Text parameter type : Fix #388

### DIFF
--- a/COMET.Web.Common.Tests/Components/ParameterTypeEditors/TextParameterTypeEditorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/ParameterTypeEditors/TextParameterTypeEditorTestFixture.cs
@@ -113,6 +113,9 @@ namespace COMET.Web.Common.Tests.Components.ParameterTypeEditors
             var textbox = this.renderedComponent.FindComponent<DxTextBox>();
             Assert.That(textbox, Is.Not.Null);
             await this.renderedComponent.InvokeAsync(() => textbox.Instance.TextChanged.InvokeAsync("value"));
+            var textboxbutton = this.renderedComponent.FindComponent<DxEditorButton>();
+            Assert.That(textboxbutton, Is.Not.Null);
+            await this.renderedComponent.InvokeAsync(() => textboxbutton.Instance.Click.InvokeAsync(null));
             var memobox = this.renderedComponent.FindComponent<DxMemo>();
             await this.renderedComponent.InvokeAsync(() => memobox.Instance.TextChanged.InvokeAsync("value"));
             Assert.That(this.eventCallbackCalled, Is.True);

--- a/COMET.Web.Common.Tests/Components/ParameterTypeEditors/TextParameterTypeEditorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/ParameterTypeEditors/TextParameterTypeEditorTestFixture.cs
@@ -113,6 +113,8 @@ namespace COMET.Web.Common.Tests.Components.ParameterTypeEditors
             var textbox = this.renderedComponent.FindComponent<DxTextBox>();
             Assert.That(textbox, Is.Not.Null);
             await this.renderedComponent.InvokeAsync(() => textbox.Instance.TextChanged.InvokeAsync("value"));
+            var memobox = this.renderedComponent.FindComponent<DxMemo>();
+            await this.renderedComponent.InvokeAsync(() => memobox.Instance.TextChanged.InvokeAsync("value"));
             Assert.That(this.eventCallbackCalled, Is.True);
         }
 

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -40,20 +40,27 @@
 else
 {
     <div class="parameter-row">
-        <DxTextBox InputCssClass="text-parameter-type"
-                   Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
-                   CssClass="parameter-input"
-                   TextChanged="@((e) => this.OpenMemoPopup(e))"
-                   ReadOnly="this.ViewModel.IsReadOnly"
-                   BindValueMode="BindValueMode.OnInput"/>
+            <Tooltip MarginBottom="bottom-60" Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]">
+                <DxTextBox Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
+                       InputCssClass="text-prameter-editor"
+                       CssClass="parameter-input"
+                       ReadOnly="true">
+                    <Buttons>
+                        <DxEditorButton IconCssClass="icon icon-edit"
+                                        Tooltip="Open Multiline editor"
+                                        Click="this.OpenMemoPopup" />
+                    </Buttons>
+                </DxTextBox>
+            </Tooltip>
         @if (this.ViewModel.Parameter?.Scale != null)
         {
             <span class="content-scale">[@this.ViewModel.Parameter.Scale.ShortName]</span>
         }
     </div>
     <DxPopup @bind-Visible="@this.IsOnEditMode" HeaderText="@this.ViewModel.ParameterType.Name" Shown="OnShown" Width="auto" CloseOnOutsideClick="true" MaxHeight="1000" MaxWidth="900" MinWidth="400">
-        <DxMemo @ref="this.multiLineEditor" Text="@this.CurrentText"
+        <DxMemo @ref="this.multiLineEditor"
                 BindValueMode="@this.BindValueMode"
+                Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
                 TextChanged="@((e) => this.ViewModel.OnParameterValueChanged(e))"
                 NullText="Type text..."
                 ReadOnly="this.ViewModel.IsReadOnly"

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -43,14 +43,23 @@ else
         <DxTextBox InputCssClass="text-parameter-type"
                    Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
                    CssClass="parameter-input"
-                   TextChanged="@((e) => this.ViewModel.OnParameterValueChanged(e))"
+                   TextChanged="@(async (e) => await this.OpenMemoPopup(e))"
                    ReadOnly="this.ViewModel.IsReadOnly"
-                   BindValueMode="@this.BindValueMode"/>
+                   BindValueMode="BindValueMode.OnInput"/>
         @if (this.ViewModel.Parameter?.Scale != null)
         {
             <span class="content-scale">[@this.ViewModel.Parameter.Scale.ShortName]</span>
         }
     </div>
+    <DxPopup @bind-Visible="@this.IsOnEditMode" Width="auto" CloseOnOutsideClick="true">
+        <DxMemo @ref="this.multiLineEditor" Text="@this.CurrentText"
+                BindValueMode="@this.BindValueMode"
+                TextChanged="@((e) => this.ViewModel.OnParameterValueChanged(e))"
+                NullText="Type text..."
+                ReadOnly="this.ViewModel.IsReadOnly"
+                CssClass="cw-480"
+                Rows="5" />
+    </DxPopup>
 }
 
 <ValidationMessageComponent ValidationMessage="@this.ViewModel.ValidationMessage" />

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -39,19 +39,19 @@
 }
 else
 {
-    <div class="parameter-row">
-            <Tooltip MarginBottom="bottom-60" Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]">
-                <DxTextBox Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
+    <div class="parameter-row-text">
+        <Tooltip MarginBottom="bottom-60 text-align-center" Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]">
+            <DxTextBox Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
                        InputCssClass="text-prameter-editor"
                        CssClass="parameter-input"
                        ReadOnly="true">
-                    <Buttons>
-                        <DxEditorButton IconCssClass="icon icon-edit"
-                                        Tooltip="Open Multiline editor"
-                                        Click="this.OpenMemoPopup" />
-                    </Buttons>
-                </DxTextBox>
-            </Tooltip>
+                <Buttons>
+                    <DxEditorButton IconCssClass="icon icon-edit"
+                                    Tooltip="Open Multiline editor"
+                                    Click="this.OpenMemoPopup" />
+                </Buttons>
+            </DxTextBox>
+        </Tooltip>     
         @if (this.ViewModel.Parameter?.Scale != null)
         {
             <span class="content-scale">[@this.ViewModel.Parameter.Scale.ShortName]</span>

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -43,7 +43,7 @@ else
         <DxTextBox InputCssClass="text-parameter-type"
                    Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
                    CssClass="parameter-input"
-                   TextChanged="@(async (e) => await this.OpenMemoPopup(e))"
+                   TextChanged="@((e) => this.OpenMemoPopup(e))"
                    ReadOnly="this.ViewModel.IsReadOnly"
                    BindValueMode="BindValueMode.OnInput"/>
         @if (this.ViewModel.Parameter?.Scale != null)
@@ -51,7 +51,7 @@ else
             <span class="content-scale">[@this.ViewModel.Parameter.Scale.ShortName]</span>
         }
     </div>
-    <DxPopup @bind-Visible="@this.IsOnEditMode" Width="auto" CloseOnOutsideClick="true">
+    <DxPopup @bind-Visible="@this.IsOnEditMode" HeaderText="@this.ViewModel.ParameterType.Name" Shown="OnShown" Width="auto" CloseOnOutsideClick="true" MaxHeight="1000" MaxWidth="900" MinWidth="400">
         <DxMemo @ref="this.multiLineEditor" Text="@this.CurrentText"
                 BindValueMode="@this.BindValueMode"
                 TextChanged="@((e) => this.ViewModel.OnParameterValueChanged(e))"

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor.cs
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor.cs
@@ -68,11 +68,18 @@ namespace COMET.Web.Common.Components.ParameterTypeEditors
         /// <summary>
         /// opens the memo popup
         /// </summary>
-        /// <returns>A <see cref="Task"/></returns>
-        private async Task OpenMemoPopup(string value)
+        private void OpenMemoPopup(string value)
         {
             this.CurrentText = value;
             this.IsOnEditMode = true;
+        }
+
+        /// <summary>
+        /// set focus on the memo popup
+        /// </summary>
+        /// <returns>A <see cref="Task"/></returns>
+        public async Task OnShown()
+        {
             await multiLineEditor.FocusAsync();
         }
 

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor.cs
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor.cs
@@ -61,16 +61,10 @@ namespace COMET.Web.Common.Components.ParameterTypeEditors
         public bool IsOnEditMode { get; set; }
 
         /// <summary>
-        /// Value of the current text
-        /// </summary>
-        public string CurrentText { get; set; }
-
-        /// <summary>
         /// opens the memo popup
         /// </summary>
-        private void OpenMemoPopup(string value)
+        private void OpenMemoPopup()
         {
-            this.CurrentText = value;
             this.IsOnEditMode = true;
         }
 

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor.cs
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor.cs
@@ -53,6 +53,29 @@ namespace COMET.Web.Common.Components.ParameterTypeEditors
         [Parameter]
         public BindValueMode BindValueMode { get; set; }
 
+        private DxMemo multiLineEditor;
+
+        /// <summary>
+        /// Value asserting that the component is on edit mode
+        /// </summary>
+        public bool IsOnEditMode { get; set; }
+
+        /// <summary>
+        /// Value of the current text
+        /// </summary>
+        public string CurrentText { get; set; }
+
+        /// <summary>
+        /// opens the memo popup
+        /// </summary>
+        /// <returns>A <see cref="Task"/></returns>
+        private async Task OpenMemoPopup(string value)
+        {
+            this.CurrentText = value;
+            this.IsOnEditMode = true;
+            await multiLineEditor.FocusAsync();
+        }
+
         /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -209,6 +209,15 @@
     justify-content: flex-start;
 }
 
+.parameter-row-text {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    position: absolute;
+    width: 9.5%;
+}
+
 .highlighted {
     color: blue;
 }
@@ -299,7 +308,7 @@
 }
 
 .tooltip-wrapper {
-    position: relative;
+    position: absolute;
     display: inline-block;
     cursor: help;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #388 

Add a button to open popup to edit TextParameterType using multiline editor.
Make TextBox readoly and add tooltip when hovering on it.

![pr-multiline-gif](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/assets/112706228/0eea6963-c28a-4b48-81d7-62cb1464e957)

<!-- Thanks for contributing to COMET-WEB! -->

