### PR TITLE
Add missing namespace to MultiComboBox component

### DIFF
--- a/COMET.Web.Common/Components/MultiComboBox.razor
+++ b/COMET.Web.Common/Components/MultiComboBox.razor
@@ -19,6 +19,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 ------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components
 @typeparam TItem
 
 <DxComboBox TValue="TItem"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Add a missing namespace to the new MultiComboBox component which was blocking the nuget package from being built.
<!-- Thanks for contributing to COMET-WEB! -->

