### PR TITLE
Issue #469 - Move book configuration to the existing ServiceConfiguration

### DIFF
--- a/COMET.Web.Common.Tests/Components/BookEditor/EditotPopupTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/BookEditor/EditotPopupTestFixture.cs
@@ -31,6 +31,7 @@ namespace COMET.Web.Common.Tests.Components.BookEditor
 
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.BookEditor;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
@@ -72,6 +73,7 @@ namespace COMET.Web.Common.Tests.Components.BookEditor
             this.context.ConfigureDevExpressBlazor();
             this.sessionService = new Mock<ISessionService>();
             this.configurationService = new Mock<IConfigurationService>();
+            this.configurationService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
             this.context.Services.AddSingleton(this.sessionService.Object);
             this.context.Services.AddSingleton(this.configurationService.Object);
             this.book = new Book();

--- a/COMET.Web.Common.Tests/Components/BookEditor/EditotPopupTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/BookEditor/EditotPopupTestFixture.cs
@@ -31,6 +31,7 @@ namespace COMET.Web.Common.Tests.Components.BookEditor
 
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.BookEditor;
+    using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
     using COMET.Web.Common.ViewModels.Components.BookEditor;
@@ -62,8 +63,7 @@ namespace COMET.Web.Common.Tests.Components.BookEditor
         private bool onCancelCalled;
         private bool onAcceptCalled;
         private Mock<ISessionService> sessionService;
-        private MockHttpMessageHandler mockHttpMessageHandler;
-        private HttpClient httpClient;
+        private Mock<IConfigurationService> configurationService;
 
         [SetUp]
         public void Setup()
@@ -71,14 +71,9 @@ namespace COMET.Web.Common.Tests.Components.BookEditor
             this.context = new TestContext();
             this.context.ConfigureDevExpressBlazor();
             this.sessionService = new Mock<ISessionService>();
+            this.configurationService = new Mock<IConfigurationService>();
             this.context.Services.AddSingleton(this.sessionService.Object);
-            this.mockHttpMessageHandler = new MockHttpMessageHandler();
-            this.httpClient = this.mockHttpMessageHandler.ToHttpClient();
-            this.httpClient.BaseAddress = new Uri("http://localhost/");
-            this.context.Services.AddScoped(_ => this.httpClient);
-            var httpResponse = new HttpResponseMessage();
-            httpResponse.Content = new StringContent("{\n  \"ShowName\": true,\n  \"ShowShortName\" : true \n}\n");
-            this.mockHttpMessageHandler.When(HttpMethod.Get, "/_content/CDP4.WEB.Common/BookInputConfiguration.json").Respond(_ => httpResponse);
+            this.context.Services.AddSingleton(this.configurationService.Object);
             this.book = new Book();
 
             this.activeDomains = new List<DomainOfExpertise>

--- a/COMET.Web.Common.Tests/Components/IndexComponentTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/IndexComponentTestFixture.cs
@@ -38,6 +38,7 @@ namespace COMET.Web.Common.Tests.Components
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Model;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.RegistrationService;
     using COMET.Web.Common.Services.SessionManagement;
@@ -68,6 +69,7 @@ namespace COMET.Web.Common.Tests.Components
             this.versionService = new Mock<IVersionService>();
             this.sessionService = new Mock<ISessionService>();
             this.serverConnectionService = new Mock<IConfigurationService>();
+            this.serverConnectionService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
             this.sourceList = new SourceList<Iteration>();
             this.sessionService.Setup(x => x.OpenIterations).Returns(this.sourceList);
 

--- a/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
@@ -29,6 +29,7 @@ namespace COMET.Web.Common.Tests.Components
 
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Model.DTO;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
@@ -57,7 +58,7 @@ namespace COMET.Web.Common.Tests.Components
         {
             this.authenticationService = new Mock<IAuthenticationService>();
             this.serverConnectionService = new Mock<IConfigurationService>();
-            this.serverConnectionService.Setup(x => x.ServerAddress).Returns("http://localhost.com");
+            this.serverConnectionService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration { ServerAddress = "http://localhost.com" });
             this.context = new TestContext();
             this.viewModel = new LoginViewModel(this.authenticationService.Object, this.serverConnectionService.Object);
             this.context.Services.AddSingleton(this.viewModel);

--- a/COMET.Web.Common.Tests/Components/SingleIterationApplicationTemplateTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/SingleIterationApplicationTemplateTestFixture.cs
@@ -36,6 +36,7 @@ namespace COMET.Web.Common.Tests.Components
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.Selectors;
     using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Services.StringTableService;
@@ -74,9 +75,11 @@ namespace COMET.Web.Common.Tests.Components
             sessionService.Setup(x => x.Session).Returns(session.Object);
             sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(new DomainOfExpertise(){Iid = Guid.NewGuid()});
             this.viewModel.Setup(x => x.SessionService).Returns(sessionService.Object);
+            var mockConfigurationService = new Mock<IConfigurationService>();
+            mockConfigurationService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.Services.AddSingleton<IOpenModelViewModel, OpenModelViewModel>();
-            this.context.Services.AddSingleton(new Mock<IConfigurationService>().Object);
+            this.context.Services.AddSingleton(mockConfigurationService.Object);
             this.context.Services.AddSingleton(new Mock<IStringTableService>().Object);
             this.context.Services.AddSingleton(sessionService.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMET.Web.Common.Tests/Resources/configuration/server_configuration.json
+++ b/COMET.Web.Common.Tests/Resources/configuration/server_configuration.json
@@ -1,3 +1,7 @@
 {
-  "ServerAddress": ""
+  "ServerAddress": "",
+  "BookInputConfiguration": {
+    "ShowName": true,
+    "ShowShortName": true
+  }
 }

--- a/COMET.Web.Common.Tests/Server/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
+++ b/COMET.Web.Common.Tests/Server/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
@@ -25,16 +25,12 @@
 
 namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
 {
-    using System.Text;
-
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Server.Services.ConfigurationService;
 
     using Microsoft.Extensions.Configuration;
 
     using Moq;
-
-    using Newtonsoft.Json;
 
     using NUnit.Framework;
 
@@ -56,13 +52,17 @@ namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
             {
                 configuration.Verify(x => x.GetSection(ConfigurationService.AddressSection), Times.Once);
                 configuration.Verify(x => x.GetSection(ConfigurationService.BookInputConfigurationSection), Times.Once);
-                Assert.That(service.ServerAddress, Is.Null);
-                Assert.That(service.BookInputConfiguration, Is.Null);
+                Assert.That(service.ServerConfiguration.ServerAddress, Is.Null);
+                Assert.That(service.ServerConfiguration.BookInputConfiguration, Is.Null);
             });
             
             await service.InitializeService();
-            configuration.Verify(x => x.GetSection(ConfigurationService.AddressSection), Times.Once);
-            configuration.Verify(x => x.GetSection(ConfigurationService.BookInputConfigurationSection), Times.Once);
+
+            Assert.Multiple(() =>
+            {
+                configuration.Verify(x => x.GetSection(ConfigurationService.AddressSection), Times.Once);
+                configuration.Verify(x => x.GetSection(ConfigurationService.BookInputConfigurationSection), Times.Once);
+            });
         }
 
         [Test]
@@ -84,10 +84,10 @@ namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
             
             Assert.Multiple(() =>
             {
-                Assert.That(service.ServerAddress, Is.EqualTo(serverAddressMockConfigurationSection.Object.Value));
-                Assert.IsNotNull(service.BookInputConfiguration);
-                Assert.That(service.BookInputConfiguration.ShowName, Is.EqualTo(bookInputConfiguration.ShowName));
-                Assert.That(service.BookInputConfiguration.ShowShortName, Is.EqualTo(bookInputConfiguration.ShowShortName));
+                Assert.That(service.ServerConfiguration.ServerAddress, Is.EqualTo(serverAddressMockConfigurationSection.Object.Value));
+                Assert.That(service.ServerConfiguration.BookInputConfiguration, Is.Not.Null);
+                Assert.That(service.ServerConfiguration.BookInputConfiguration.ShowName, Is.EqualTo(bookInputConfiguration.ShowName));
+                Assert.That(service.ServerConfiguration.BookInputConfiguration.ShowShortName, Is.EqualTo(bookInputConfiguration.ShowShortName));
             });
         }
     }

--- a/COMET.Web.Common.Tests/WebAssembly/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
+++ b/COMET.Web.Common.Tests/WebAssembly/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
@@ -96,7 +96,7 @@ namespace COMET.Web.Common.Tests.WebAssembly.Services.ConfigurationService
             httpResponse.StatusCode = HttpStatusCode.OK;
             httpResponse.Content = new StringContent("{\"ServerAddress\":\"http://localhost\"}");
             await this.configurationService.InitializeService();
-            Assert.That(this.configurationService.ServerAddress, Is.EqualTo("http://localhost"));
+            Assert.That(this.configurationService.ServerConfiguration.ServerAddress, Is.EqualTo("http://localhost"));
         }
     }
 }

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
     <PackageReference Include="ReactiveUI" Version="18.4.26" />
   </ItemGroup>
   <ItemGroup>

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
     <PackageReference Include="ReactiveUI" Version="18.4.26" />
   </ItemGroup>
   <ItemGroup>
@@ -45,9 +46,6 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
     <Content Update="wwwroot\DefaultTextConfiguration.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Update="wwwroot\BookInputConfiguration.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Update="wwwroot\server_configuration.json">

--- a/COMET.Web.Common/Components/BookEditor/EditorPopup.razor.cs
+++ b/COMET.Web.Common/Components/BookEditor/EditorPopup.razor.cs
@@ -30,7 +30,9 @@ namespace COMET.Web.Common.Components.BookEditor
     using CDP4Common.ReportingData;
 
     using COMET.Web.Common.Model;
+    using COMET.Web.Common.Model.DTO;
     using COMET.Web.Common.Services;
+    using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Utilities;
     using COMET.Web.Common.ViewModels.Components.BookEditor;
 
@@ -57,7 +59,7 @@ namespace COMET.Web.Common.Components.BookEditor
         /// Gets or sets the <see cref="HttpClient"/>
         /// </summary>
         [Inject]
-        public HttpClient HttpClient { get; set; }
+        public IConfigurationService ConfigurationService { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IOptions{TOptions}"/>
@@ -100,40 +102,11 @@ namespace COMET.Web.Common.Components.BookEditor
         {
             await base.OnInitializedAsync();
             this.Disposables.Add(this.ViewModel.ValidationErrors.Connect().Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
-            
-            var jsonFile = this.Options.Value.JsonConfigurationFile ?? "BookInputConfiguration.json";
+            var configurations = this.ConfigurationService.BookInputConfiguration;
 
-            try
-            {
-                var configurations = await this.GetBookInputConfigurationAsync(jsonFile);
-
-                if (configurations.TryGetValue(showNameConfigurationProperty, out var showNameValue))
-                {
-                    this.showName = showNameValue;
-                }
-
-                if (configurations.TryGetValue(showShortNameConfigurationProperty, out var showShortNameValue))
-                {
-                    this.showShortName = showShortNameValue;
-                }
-            }
-            catch (Exception e)
-            {
-                this.Logger.LogError(e, "Error while getting the configuration file.");
-            }
-        }
-        
-        /// <summary>
-        /// Acquires the BookInput configurations
-        /// </summary>
-        /// <param name="fileName">The file name that contains the configurations</param>
-        /// <returns>A KeyValuePair collection with each available configuration</returns>
-        private async Task<Dictionary<string, bool>> GetBookInputConfigurationAsync(string fileName)
-        {
-            var path = ContentPathBuilder.BuildPath(fileName);
-            var jsonContent = await this.HttpClient.GetStreamAsync(path);
-            var configurations = JsonSerializer.Deserialize<Dictionary<string, bool>>(jsonContent);
-            return configurations;
+            //The fields will be shown by default
+            this.showName = configurations?.ShowName ?? true;
+            this.showShortName = configurations?.ShowShortName ?? true;
         }
 
         /// <summary>

--- a/COMET.Web.Common/Components/BookEditor/EditorPopup.razor.cs
+++ b/COMET.Web.Common/Components/BookEditor/EditorPopup.razor.cs
@@ -102,7 +102,7 @@ namespace COMET.Web.Common.Components.BookEditor
         {
             await base.OnInitializedAsync();
             this.Disposables.Add(this.ViewModel.ValidationErrors.Connect().Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
-            var configurations = this.ConfigurationService.BookInputConfiguration;
+            var configurations = this.ConfigurationService.ServerConfiguration.BookInputConfiguration;
 
             //The fields will be shown by default
             this.showName = configurations?.ShowName ?? true;

--- a/COMET.Web.Common/Components/BookEditor/EditorPopup.razor.cs
+++ b/COMET.Web.Common/Components/BookEditor/EditorPopup.razor.cs
@@ -76,19 +76,9 @@ namespace COMET.Web.Common.Components.BookEditor
         private bool showName;
 
         /// <summary>
-        /// The name of the ShowName property on the configuration file
-        /// </summary>
-        private const string showNameConfigurationProperty = "ShowName";
-
-        /// <summary>
         /// Sets if the component should show the shorname field
         /// </summary>
         private bool showShortName;
-
-        /// <summary>
-        /// The name of the ShowShortName property on the configuration file
-        /// </summary>
-        private const string showShortNameConfigurationProperty = "ShowShortName";
 
         /// <summary>
         /// Method invoked when the component is ready to start, having received its

--- a/COMET.Web.Common/Components/Login.razor
+++ b/COMET.Web.Common/Components/Login.razor
@@ -25,7 +25,7 @@
 <EditForm Context="editFormContext" Model="@(this.ViewModel.AuthenticationDto)" OnValidSubmit="this.ExecuteLogin">
 	<DataAnnotationsValidator/>
 	<DxFormLayout CaptionPosition="CaptionPosition.Vertical">
-		@if (string.IsNullOrEmpty(this.ViewModel.serverConnectionService.ServerAddress))
+		@if (string.IsNullOrEmpty(this.ViewModel.serverConnectionService.ServerConfiguration.ServerAddress))
 		{
 			<DxFormLayoutItem Caption="Source Address:" ColSpanLg="12">
 				<Template>

--- a/COMET.Web.Common/Components/SingleIterationApplicationTemplate.razor.cs
+++ b/COMET.Web.Common/Components/SingleIterationApplicationTemplate.razor.cs
@@ -150,7 +150,7 @@ namespace COMET.Web.Common.Components
                 currentOptions[QueryKeys.IterationKey] = this.ViewModel.SelectedIteration.Iid.ToShortGuid();
                 currentOptions[QueryKeys.ModelKey] = this.ViewModel.SelectedIteration.IterationSetup.Container.Iid.ToShortGuid();
 
-                if (string.IsNullOrEmpty(this.ServerConnectionService.ServerAddress))
+                if (string.IsNullOrEmpty(this.ServerConnectionService.ServerConfiguration.ServerAddress))
                 {
                     currentOptions[QueryKeys.ServerKey] = this.ViewModel.SessionService.Session.DataSourceUri;
 

--- a/COMET.Web.Common/Model/Configuration/BookInputConfiguration.cs
+++ b/COMET.Web.Common/Model/Configuration/BookInputConfiguration.cs
@@ -1,0 +1,42 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="BookInputConfigurationDto.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Model.Configuration;
+
+using System.Text.Json.Serialization;
+
+public class BookInputConfiguration
+{
+    /// <summary>
+    /// Verifies if the Name field will be displayed on the Book Input form
+    /// </summary>
+    [JsonPropertyName("ShowName")]
+    public bool ShowName { get; set; }
+
+    /// <summary>
+    /// Verifies if the ShortName field will be displayed on the Book Input form
+    /// </summary>
+    [JsonPropertyName("ShowShortName")]
+    public bool ShowShortName { get; set; }
+}

--- a/COMET.Web.Common/Model/Configuration/BookInputConfiguration.cs
+++ b/COMET.Web.Common/Model/Configuration/BookInputConfiguration.cs
@@ -31,12 +31,10 @@ public class BookInputConfiguration
     /// <summary>
     /// Verifies if the Name field will be displayed on the Book Input form
     /// </summary>
-    [JsonPropertyName("ShowName")]
     public bool ShowName { get; set; }
 
     /// <summary>
     /// Verifies if the ShortName field will be displayed on the Book Input form
     /// </summary>
-    [JsonPropertyName("ShowShortName")]
     public bool ShowShortName { get; set; }
 }

--- a/COMET.Web.Common/Model/Configuration/BookInputConfiguration.cs
+++ b/COMET.Web.Common/Model/Configuration/BookInputConfiguration.cs
@@ -24,8 +24,9 @@
 
 namespace COMET.Web.Common.Model.Configuration;
 
-using System.Text.Json.Serialization;
-
+/// <summary>
+/// Holds all of the configuration related to the Book feature
+/// </summary>
 public class BookInputConfiguration
 {
     /// <summary>

--- a/COMET.Web.Common/Model/Configuration/ServerConfiguration.cs
+++ b/COMET.Web.Common/Model/Configuration/ServerConfiguration.cs
@@ -24,13 +24,18 @@
 
 namespace COMET.Web.Common.Model.Configuration;
 
-using System.Text.Json.Serialization;
-
+/// <summary>
+/// This class holds all of the configuration related properties that are stored on the local configuration files.
+/// </summary>
 public class ServerConfiguration
 {
-    [JsonPropertyName("ServerAddress")]
+    /// <summary>
+    /// The Server Address to use
+    /// </summary>
     public string ServerAddress { get; set; }
 
-    [JsonPropertyName("BookInputConfiguration")]
+    /// <summary>
+    /// The configuration values for the Book feature
+    /// </summary>
     public BookInputConfiguration BookInputConfiguration { get; set; }
 }

--- a/COMET.Web.Common/Model/Configuration/ServerConfiguration.cs
+++ b/COMET.Web.Common/Model/Configuration/ServerConfiguration.cs
@@ -1,0 +1,36 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ServerConfiguration.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Model.Configuration;
+
+using System.Text.Json.Serialization;
+
+public class ServerConfiguration
+{
+    [JsonPropertyName("ServerAddress")]
+    public string ServerAddress { get; set; }
+
+    [JsonPropertyName("BookInputConfiguration")]
+    public BookInputConfiguration BookInputConfiguration { get; set; }
+}

--- a/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
@@ -25,6 +25,10 @@
 
 namespace COMET.Web.Common.Server.Services.ConfigurationService
 {
+    using System.Text.Json;
+
+    using COMET.Web.Common.Model.Configuration;
+    using COMET.Web.Common.Model.DTO;
     using COMET.Web.Common.Services.ConfigurationService;
 
     using Microsoft.Extensions.Configuration;
@@ -38,6 +42,11 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
         /// Gets the ServerAddress section key
         /// </summary>
         public const string AddressSection = "ServerAddress";
+
+        /// <summary>
+        /// Gets the BookInputConfiguration section key
+        /// </summary>
+        public const string BookInputConfigurationSection = "BookInputConfiguration";
 
         /// <summary>
         /// Gets the <see cref="IConfiguration" />
@@ -71,6 +80,13 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
                 this.ServerAddress = addressSection.Value;
             }
 
+            var bookInputConfigurationSection = this.configuration.GetSection(BookInputConfigurationSection);
+
+            if (bookInputConfigurationSection.Exists())
+            {
+                this.BookInputConfiguration = JsonSerializer.Deserialize<BookInputConfiguration>(bookInputConfigurationSection.Value);
+            }
+            
             this.IsInitialized = true;
             return Task.CompletedTask;
         }

--- a/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
@@ -73,18 +73,20 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
                 return Task.CompletedTask;
             }
 
+            this.ServerConfiguration = new ServerConfiguration();
+            
             var addressSection = this.configuration.GetSection(AddressSection);
 
             if (addressSection.Exists())
             {
-                this.ServerAddress = addressSection.Value;
+                this.ServerConfiguration.ServerAddress = addressSection.Value;
             }
 
             var bookInputConfigurationSection = this.configuration.GetSection(BookInputConfigurationSection);
 
             if (bookInputConfigurationSection.Exists())
             {
-                this.BookInputConfiguration = JsonSerializer.Deserialize<BookInputConfiguration>(bookInputConfigurationSection.Value);
+                this.ServerConfiguration.BookInputConfiguration = JsonSerializer.Deserialize<BookInputConfiguration>(bookInputConfigurationSection.Value);
             }
             
             this.IsInitialized = true;

--- a/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
@@ -39,14 +39,9 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
     public class ConfigurationService : BaseConfigurationService
     {
         /// <summary>
-        /// Gets the ServerAddress section key
+        /// Gets the ServerConfiguration section key
         /// </summary>
-        public const string AddressSection = "ServerAddress";
-
-        /// <summary>
-        /// Gets the BookInputConfiguration section key
-        /// </summary>
-        public const string BookInputConfigurationSection = "BookInputConfiguration";
+        public const string ServerConfigurationSection = "ServerConfiguration";
 
         /// <summary>
         /// Gets the <see cref="IConfiguration" />
@@ -74,19 +69,12 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
             }
 
             this.ServerConfiguration = new ServerConfiguration();
+
+            var serverConfigurationSection = this.configuration.GetSection(ServerConfigurationSection);
             
-            var addressSection = this.configuration.GetSection(AddressSection);
-
-            if (addressSection.Exists())
+            if (serverConfigurationSection.Exists())
             {
-                this.ServerConfiguration.ServerAddress = addressSection.Value;
-            }
-
-            var bookInputConfigurationSection = this.configuration.GetSection(BookInputConfigurationSection);
-
-            if (bookInputConfigurationSection.Exists())
-            {
-                this.ServerConfiguration.BookInputConfiguration = JsonSerializer.Deserialize<BookInputConfiguration>(bookInputConfigurationSection.Value);
+                this.ServerConfiguration = JsonSerializer.Deserialize<ServerConfiguration>(serverConfigurationSection.Value);
             }
             
             this.IsInitialized = true;

--- a/COMET.Web.Common/Services/ConfigurationService/BaseConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/BaseConfigurationService.cs
@@ -26,7 +26,6 @@
 namespace COMET.Web.Common.Services.ConfigurationService
 {
     using COMET.Web.Common.Model.Configuration;
-    using COMET.Web.Common.Model.DTO;
 
     /// <summary>
     /// Base Service that holds the configuration for the application
@@ -39,14 +38,9 @@ namespace COMET.Web.Common.Services.ConfigurationService
         protected bool IsInitialized { get; set; }
 
         /// <summary>
-        /// The Server Address to use
+        /// Holds all of the configuration related values
         /// </summary>
-        public string ServerAddress { get; protected set; }
-        
-        /// <summary>
-        /// The configuration values for the Book feature
-        /// </summary>
-        public BookInputConfiguration BookInputConfiguration { get; protected set; }
+        public ServerConfiguration ServerConfiguration { get; set; }
 
         /// <summary>
         /// Initializes the <see cref="IConfigurationService"/>

--- a/COMET.Web.Common/Services/ConfigurationService/BaseConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/BaseConfigurationService.cs
@@ -25,6 +25,9 @@
 
 namespace COMET.Web.Common.Services.ConfigurationService
 {
+    using COMET.Web.Common.Model.Configuration;
+    using COMET.Web.Common.Model.DTO;
+
     /// <summary>
     /// Base Service that holds the configuration for the application
     /// </summary>
@@ -39,6 +42,11 @@ namespace COMET.Web.Common.Services.ConfigurationService
         /// The Server Address to use
         /// </summary>
         public string ServerAddress { get; protected set; }
+        
+        /// <summary>
+        /// The configuration values for the Book feature
+        /// </summary>
+        public BookInputConfiguration BookInputConfiguration { get; protected set; }
 
         /// <summary>
         /// Initializes the <see cref="IConfigurationService"/>

--- a/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
@@ -26,7 +26,6 @@
 namespace COMET.Web.Common.Services.ConfigurationService
 {
     using COMET.Web.Common.Model.Configuration;
-    using COMET.Web.Common.Model.DTO;
 
     /// <summary>
     /// Service that holds the configuration for the application
@@ -36,7 +35,7 @@ namespace COMET.Web.Common.Services.ConfigurationService
         /// <summary>
         /// Holds all of the configuration related values
         /// </summary>
-        public ServerConfiguration ServerConfiguration { get; set; }
+        ServerConfiguration ServerConfiguration { get; set; }
 
         /// <summary>
         /// Initializes the <see cref="IConfigurationService"/>

--- a/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
@@ -34,14 +34,9 @@ namespace COMET.Web.Common.Services.ConfigurationService
     public interface IConfigurationService
     {
         /// <summary>
-        /// The Server Address to use
+        /// Holds all of the configuration related values
         /// </summary>
-        string ServerAddress { get; }
-        
-        /// <summary>
-        /// The configuration values for the Book feature
-        /// </summary>
-        BookInputConfiguration BookInputConfiguration { get; }
+        public ServerConfiguration ServerConfiguration { get; set; }
 
         /// <summary>
         /// Initializes the <see cref="IConfigurationService"/>

--- a/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
+++ b/COMET.Web.Common/Services/ConfigurationService/IConfigurationService.cs
@@ -25,6 +25,9 @@
 
 namespace COMET.Web.Common.Services.ConfigurationService
 {
+    using COMET.Web.Common.Model.Configuration;
+    using COMET.Web.Common.Model.DTO;
+
     /// <summary>
     /// Service that holds the configuration for the application
     /// </summary>
@@ -34,6 +37,11 @@ namespace COMET.Web.Common.Services.ConfigurationService
         /// The Server Address to use
         /// </summary>
         string ServerAddress { get; }
+        
+        /// <summary>
+        /// The configuration values for the Book feature
+        /// </summary>
+        BookInputConfiguration BookInputConfiguration { get; }
 
         /// <summary>
         /// Initializes the <see cref="IConfigurationService"/>

--- a/COMET.Web.Common/ViewModels/Components/LoginViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/LoginViewModel.cs
@@ -83,9 +83,9 @@ namespace COMET.Web.Common.ViewModels.Components
         {
             this.AuthenticationState = AuthenticationStateKind.Authenticating;
 
-            if(!string.IsNullOrEmpty(this.serverConnectionService.ServerAddress))
+            if(!string.IsNullOrEmpty(this.serverConnectionService.ServerConfiguration.ServerAddress))
             {
-                this.AuthenticationDto.SourceAddress = this.serverConnectionService.ServerAddress;
+                this.AuthenticationDto.SourceAddress = this.serverConnectionService.ServerConfiguration.ServerAddress;
             }
 
             this.AuthenticationState = await this.authenticationService.Login(this.AuthenticationDto);

--- a/COMET.Web.Common/WebAssembly/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/WebAssembly/Services/ConfigurationService/ConfigurationService.cs
@@ -88,9 +88,8 @@ namespace COMET.Web.Common.WebAssembly.Services.ConfigurationService
                 if (response.IsSuccessStatusCode)
                 {
                     var jsonContent = await response.Content.ReadAsStreamAsync();
-                    var configurations = JsonSerializer.Deserialize<ServerConfiguration>(jsonContent);
-                    this.ServerAddress = configurations.ServerAddress;
-                    this.BookInputConfiguration = configurations.BookInputConfiguration;
+                    var serverConfiguration = JsonSerializer.Deserialize<ServerConfiguration>(jsonContent);
+                    this.ServerConfiguration = serverConfiguration;
                 }
                 else if (response.StatusCode == HttpStatusCode.NotFound)
                 {

--- a/COMET.Web.Common/WebAssembly/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/WebAssembly/Services/ConfigurationService/ConfigurationService.cs
@@ -29,6 +29,7 @@ namespace COMET.Web.Common.WebAssembly.Services.ConfigurationService
     using System.Text.Json;
 
     using COMET.Web.Common.Model;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Utilities;
 
@@ -87,8 +88,9 @@ namespace COMET.Web.Common.WebAssembly.Services.ConfigurationService
                 if (response.IsSuccessStatusCode)
                 {
                     var jsonContent = await response.Content.ReadAsStreamAsync();
-                    var configurations = JsonSerializer.Deserialize<Dictionary<string, string>>(jsonContent);
-                    this.ServerAddress = configurations["ServerAddress"];
+                    var configurations = JsonSerializer.Deserialize<ServerConfiguration>(jsonContent);
+                    this.ServerAddress = configurations.ServerAddress;
+                    this.BookInputConfiguration = configurations.BookInputConfiguration;
                 }
                 else if (response.StatusCode == HttpStatusCode.NotFound)
                 {

--- a/COMET.Web.Common/wwwroot/BookInputConfiguration.json
+++ b/COMET.Web.Common/wwwroot/BookInputConfiguration.json
@@ -1,4 +1,0 @@
-{
-  "ShowName": true,
-  "ShowShortName" : true 
-}

--- a/COMET.Web.Common/wwwroot/server_configuration.json
+++ b/COMET.Web.Common/wwwroot/server_configuration.json
@@ -1,7 +1,9 @@
 {
-  "ServerAddress": "",
-  "BookInputConfiguration": {
-    "ShowName": true,
-    "ShowShortName": true
+  "ServerConfiguration": {
+    "ServerAddress": "",
+    "BookInputConfiguration": {
+      "ShowName": true,
+      "ShowShortName": true
+    }
   }
 }

--- a/COMET.Web.Common/wwwroot/server_configuration.json
+++ b/COMET.Web.Common/wwwroot/server_configuration.json
@@ -1,3 +1,7 @@
 {
-  "ServerAddress": ""
+  "ServerAddress": "",
+  "BookInputConfiguration": {
+    "ShowName": true,
+    "ShowShortName": true
+  }
 }

--- a/COMETwebapp.Tests/Components/BookEditor/BookEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/BookEditor/BookEditorBodyTestFixture.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.Tests.Components.BookEditor
     using CDP4Common.ReportingData;
     using CDP4Common.SiteDirectoryData;
 
+    using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
     using COMET.Web.Common.ViewModels.Components;
@@ -61,6 +62,7 @@ namespace COMETwebapp.Tests.Components.BookEditor
         private Section selectedSection;
         private Page selectedPage;
         private Note selectedNote;
+        private Mock<IConfigurationService> configurationService;
 
         [SetUp]
         public void Setup()
@@ -68,6 +70,7 @@ namespace COMETwebapp.Tests.Components.BookEditor
             this.context = new TestContext();
             this.context.ConfigureDevExpressBlazor();
             this.sessionService = new Mock<ISessionService>();
+            this.configurationService = new Mock<IConfigurationService>();
 
             this.selectedBook = new Book();
             this.selectedSection = new Section();
@@ -106,6 +109,7 @@ namespace COMETwebapp.Tests.Components.BookEditor
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.Services.AddSingleton(this.sessionService.Object);
+            this.context.Services.AddSingleton(this.configurationService.Object);
             this.context.Services.AddSingleton(domDataService.Object);
 
             this.component = this.context.RenderComponent<BookEditorBody>();

--- a/COMETwebapp.Tests/Components/BookEditor/BookEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/BookEditor/BookEditorBodyTestFixture.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.Tests.Components.BookEditor
     using CDP4Common.ReportingData;
     using CDP4Common.SiteDirectoryData;
 
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
@@ -71,6 +72,7 @@ namespace COMETwebapp.Tests.Components.BookEditor
             this.context.ConfigureDevExpressBlazor();
             this.sessionService = new Mock<ISessionService>();
             this.configurationService = new Mock<IConfigurationService>();
+            this.configurationService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
 
             this.selectedBook = new Book();
             this.selectedSection = new Section();

--- a/COMETwebapp.Tests/Pages/ModelDashboard/ModelDashboardTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ModelDashboard/ModelDashboardTestFixture.cs
@@ -34,6 +34,7 @@ namespace COMETwebapp.Tests.Pages.ModelDashboard
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.Selectors;
     using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Services.StringTableService;
@@ -112,10 +113,13 @@ namespace COMETwebapp.Tests.Pages.ModelDashboard
                 }
             };
 
+            var mockConfigurationService = new Mock<IConfigurationService>();
+            mockConfigurationService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
+
             this.context.ConfigureDevExpressBlazor();
             this.context.Services.AddSingleton(this.viewModel);
             this.context.Services.AddSingleton(this.sessionService.Object);
-            this.context.Services.AddSingleton(new Mock<IConfigurationService>().Object);
+            this.context.Services.AddSingleton(mockConfigurationService.Object);
             this.context.Services.AddSingleton<IOpenModelViewModel, OpenModelViewModel>();
             this.context.Services.AddSingleton<IModelDashboardBodyViewModel, ModelDashboardBodyViewModel>();
             this.context.Services.AddSingleton<IParameterDashboardViewModel, ParameterDashboardViewModel>();

--- a/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
@@ -34,6 +34,7 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.Selectors;
     using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.NotificationService;
     using COMET.Web.Common.Services.SessionManagement;
@@ -113,6 +114,9 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
                     }
                 }
             };
+            
+            var mockConfigurationService = new Mock<IConfigurationService>();
+            mockConfigurationService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
 
             this.context.ConfigureDevExpressBlazor();
             this.context.Services.AddSingleton(this.viewModel);
@@ -122,7 +126,7 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
             this.context.Services.AddSingleton<ISubscriptionService, SubscriptionService>();
             this.context.Services.AddSingleton<IParameterTableViewModel, ParameterTableViewModel>();
             this.context.Services.AddSingleton<INotificationService, NotificationService>();
-            this.context.Services.AddSingleton(new Mock<IConfigurationService>().Object);
+            this.context.Services.AddSingleton(mockConfigurationService.Object);
 
             var configurationService = new Mock<IStringTableService>();
             configurationService.Setup(x => x.GetText(It.IsAny<string>())).Returns("something");

--- a/COMETwebapp.Tests/Pages/Viewer/ViewerTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/Viewer/ViewerTestFixture.cs
@@ -34,6 +34,7 @@ namespace COMETwebapp.Tests.Pages.Viewer
     using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.Selectors;
     using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Services.StringTableService;
@@ -113,6 +114,9 @@ namespace COMETwebapp.Tests.Pages.Viewer
                     }
                 }
             };
+            
+            var mockConfigurationService = new Mock<IConfigurationService>();
+            mockConfigurationService.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
 
             this.context.ConfigureDevExpressBlazor();
             this.context.Services.AddSingleton(this.viewModel);
@@ -120,7 +124,7 @@ namespace COMETwebapp.Tests.Pages.Viewer
             this.context.Services.AddSingleton<IOpenModelViewModel, OpenModelViewModel>();
             this.context.Services.AddSingleton<IViewerBodyViewModel, ViewerBodyViewModel>();
             this.context.Services.AddSingleton<ISubscriptionService, SubscriptionService>();
-            this.context.Services.AddSingleton(new Mock<IConfigurationService>().Object);
+            this.context.Services.AddSingleton(mockConfigurationService.Object);
             this.context.Services.AddSingleton<ISelectionMediator, SelectionMediator>();
             this.context.Services.AddSingleton<IBabylonInterop, BabylonInterop>();
             this.context.Services.AddSingleton<IActualFiniteStateSelectorViewModel, ActualFiniteStateSelectorViewModel>();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This change moves the need to use an HttpClient when we're required to access the BookInputConfiguration files.
The changes made here also allow for us to leverage the full power of .NET's IConfiguration implementation and interpret complex JSON objects and not only KeyValuePairs, which allows for some better organization of our setting files.
The changes here affect both WASM and Server modes, where as WASM will read the data from the server_configuration.json file (as it had been doing) and Server should be looking at the appsettings.json file.
<!-- Thanks for contributing to COMET-WEB! -->

