### PR TITLE
Fix the way configuration was being bound, to make it work for complex objects.

### DIFF
--- a/COMET.Web.Common.Tests/COMET.Web.Common.Tests.csproj
+++ b/COMET.Web.Common.Tests/COMET.Web.Common.Tests.csproj
@@ -35,6 +35,10 @@
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Content>
+      <None Remove="Data\server_configuration_tests.json" />
+      <Content Include="Data\server_configuration_tests.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
     <ItemGroup>

--- a/COMET.Web.Common.Tests/Data/server_configuration_tests.json
+++ b/COMET.Web.Common.Tests/Data/server_configuration_tests.json
@@ -1,0 +1,9 @@
+{
+  "ServerConfiguration": {
+    "ServerAddress": "https://a.b.c",
+    "BookInputConfiguration": {
+      "ShowName": true,
+      "ShowShortName": true
+    }
+  }
+}

--- a/COMET.Web.Common.Tests/Server/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
+++ b/COMET.Web.Common.Tests/Server/Services/ConfigurationService/ConfigurationServiceTestFixture.cs
@@ -25,8 +25,6 @@
 
 namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
 {
-    using System.Text.Json;
-
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Server.Services.ConfigurationService;
 
@@ -50,8 +48,7 @@ namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
             Assert.Multiple(() =>
             {
                 configuration.Verify(x => x.GetSection(ConfigurationService.ServerConfigurationSection), Times.Once);
-                Assert.That(service.ServerConfiguration.ServerAddress, Is.Null);
-                Assert.That(service.ServerConfiguration.BookInputConfiguration, Is.Null);
+                Assert.That(service.ServerConfiguration, Is.Null);
             });
             
             await service.InitializeService();
@@ -65,8 +62,6 @@ namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
         [Test]
         public async Task VerifyInitializeServiceWithConfiguration()
         {
-            var serverAddressMockConfigurationSection = new Mock<IConfigurationSection>();
-
             var serverConfiguration = new ServerConfiguration
             {
                 ServerAddress = "https://a.b.c",
@@ -76,13 +71,12 @@ namespace COMET.Web.Common.Tests.Server.Services.ConfigurationService
                     ShowShortName = true
                 }
             };
-
-            var serverConfigurationJson = JsonSerializer.Serialize(serverConfiguration);
-            serverAddressMockConfigurationSection.Setup(x => x.Value).Returns(serverConfigurationJson);
             
-            var configuration = new Mock<IConfiguration>();
-            configuration.Setup(x => x.GetSection(ConfigurationService.ServerConfigurationSection)).Returns(serverAddressMockConfigurationSection.Object);
-            var service = new ConfigurationService(configuration.Object);
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("Data/server_configuration_tests.json")
+                .Build();
+            
+            var service = new ConfigurationService(config);
             await service.InitializeService();
             
             Assert.Multiple(() =>

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
     <PackageReference Include="ReactiveUI" Version="18.4.26" />
   </ItemGroup>
   <ItemGroup>

--- a/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
@@ -25,8 +25,6 @@
 
 namespace COMET.Web.Common.Server.Services.ConfigurationService
 {
-    using System.Text.Json;
-
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
 

--- a/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
+++ b/COMET.Web.Common/Server/Services/ConfigurationService/ConfigurationService.cs
@@ -28,7 +28,6 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
     using System.Text.Json;
 
     using COMET.Web.Common.Model.Configuration;
-    using COMET.Web.Common.Model.DTO;
     using COMET.Web.Common.Services.ConfigurationService;
 
     using Microsoft.Extensions.Configuration;
@@ -68,15 +67,7 @@ namespace COMET.Web.Common.Server.Services.ConfigurationService
                 return Task.CompletedTask;
             }
 
-            this.ServerConfiguration = new ServerConfiguration();
-
-            var serverConfigurationSection = this.configuration.GetSection(ServerConfigurationSection);
-            
-            if (serverConfigurationSection.Exists())
-            {
-                this.ServerConfiguration = JsonSerializer.Deserialize<ServerConfiguration>(serverConfigurationSection.Value);
-            }
-            
+            this.ServerConfiguration = this.configuration.GetSection(ServerConfigurationSection).Get<ServerConfiguration>();
             this.IsInitialized = true;
             return Task.CompletedTask;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Essentially, doing a .GetSection() doesn't retrieve the whole object - for that we have to use .Bind() (which I tried at first, but ran into issues while doing unit tests).
For the unit tests to work, a IConfiguration container had to be built, because there's no way to mock the .Bind() method to make it work for tests (it's a static method).
<!-- Thanks for contributing to COMET-WEB! -->

