### PR TITLE
Add the ability to override the TopMenu component on the MainLayout via IOC

### DIFF
--- a/COMET.Web.Common.Tests/Shared/TopMenuTestFixture.cs
+++ b/COMET.Web.Common.Tests/Shared/TopMenuTestFixture.cs
@@ -87,7 +87,12 @@ namespace COMET.Web.Common.Tests.Shared
             this.autoRefreshService = new Mock<IAutoRefreshService>();
             this.sourceList = new SourceList<Iteration>();
             this.sessionService.Setup(x => x.OpenIterations).Returns(this.sourceList);
-            this.registeredMenuEntries = new List<Type>();
+            this.registeredMenuEntries = new List<Type>()
+            {
+                typeof(ApplicationMenu),
+                typeof(ModelMenu),
+                typeof(SessionMenu)
+            };
             this.registeredApplications = new List<Application>();
             this.registrationService = new Mock<IRegistrationService>();
             this.registrationService.Setup(x => x.RegisteredAuthorizedMenuEntries).Returns(this.registeredMenuEntries);

--- a/COMET.Web.Common/Shared/TopMenu.razor
+++ b/COMET.Web.Common/Shared/TopMenu.razor
@@ -39,10 +39,6 @@
             }
         </TitleTemplate>
         <Items>
-            <ApplicationMenu />
-            <ModelMenu />
-            <SessionMenu />
-            
             @foreach (var menuEntry in this.RegistrationService.RegisteredAuthorizedMenuEntries.Where(x => x.IsSubclassOf(typeof(MenuEntryBase))))
             {
                 <DynamicComponent Type="@menuEntry"/>

--- a/COMETwebapp/Program.cs
+++ b/COMETwebapp/Program.cs
@@ -50,6 +50,7 @@ namespace COMETwebapp
     using System.Reflection;
 
     using COMET.Web.Common;
+    using COMET.Web.Common.Shared.TopMenuEntry;
 
     using COMETwebapp.ViewModels.Components.BookEditor;
 
@@ -75,7 +76,7 @@ namespace COMETwebapp
             {
                 options.Applications = Applications.ExistingApplications;
                 options.AdditionalAssemblies.Add(Assembly.GetAssembly(typeof(Program)));
-                options.AdditionalMenuEntries.AddRange(new List<Type>{typeof(ShowHideDeprecatedThings), typeof(AboutMenu)});
+                options.AdditionalMenuEntries.AddRange(new List<Type>{ typeof(ApplicationMenu), typeof(ModelMenu), typeof(SessionMenu), typeof(ShowHideDeprecatedThings), typeof(AboutMenu)});
             });
             
             builder.Services.AddScoped(_ => new HttpClient()


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This will allow us to override the TopMenu component that is rendered on the MainLayout.
<!-- Thanks for contributing to COMET-WEB! -->

