### PR TITLE
Fix #477- ApplicationTemplate can be used as is

### DIFF
--- a/COMET.Web.Common.Tests/Components/Applications/ApplicationTemplateTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Applications/ApplicationTemplateTestFixture.cs
@@ -1,0 +1,90 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ApplicationTemplateTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023 RHEA System S.A.
+// 
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine
+// 
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Applications
+{
+    using CDP4Dal;
+    using CDP4Dal.DAL;
+
+    using COMET.Web.Common.Components.Applications;
+    using COMET.Web.Common.Model.Configuration;
+    using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using TestContext = Bunit.TestContext;
+
+    [TestFixture]
+    public class ApplicationTemplateTestFixture
+    {
+        private TestContext context;
+        private Mock<IApplicationTemplateViewModel> viewModel;
+        private Mock<ISessionService> sessionService;
+        private Mock<IConfigurationService> configurationService;
+        private ServerConfiguration configuration;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new TestContext();
+            this.viewModel = new Mock<IApplicationTemplateViewModel>();
+            this.sessionService = new Mock<ISessionService>();
+            this.configurationService = new Mock<IConfigurationService>();
+            this.configuration = new ServerConfiguration();
+            this.configurationService.Setup(x => x.ServerConfiguration).Returns(this.configuration);
+            this.viewModel.Setup(x => x.SessionService).Returns(this.sessionService.Object);
+            var session = new Mock<ISession>();
+            session.Setup(x => x.DataSourceUri).Returns("abc");
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.context.Services.AddSingleton(this.configurationService.Object);
+            this.context.Services.AddSingleton(this.viewModel.Object);
+        }
+
+        [Test]
+        public void VerifyApplicationTemplateWithoutDefinedAddress()
+        {
+            this.context.RenderComponent<ApplicationTemplate>();
+            var navigationManager = this.context.Services.GetService<NavigationManager>();
+            Assert.That(navigationManager.Uri, Does.Contain($"{QueryKeys.ServerKey}=abc"));
+        }
+
+        [Test]
+        public void VerifyApplicationTemplateWithDefinedAddress()
+        {
+            this.configuration.ServerAddress = "abc";
+            this.context.RenderComponent<ApplicationTemplate>();
+            var navigationManager = this.context.Services.GetService<NavigationManager>();
+            Assert.That(navigationManager.Uri, Does.Not.Contain($"{QueryKeys.ServerKey}=abc"));
+        }
+    }
+}

--- a/COMET.Web.Common/Components/Applications/ApplicationTemplate.razor
+++ b/COMET.Web.Common/Components/Applications/ApplicationTemplate.razor
@@ -1,24 +1,23 @@
 ﻿<!------------------------------------------------------------------------------
 // Copyright (c) 2023 RHEA System S.A.
 //
-//   Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
 //
-//   This file is part of COMET WEB Community Edition
-//   The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25
-//   Annex A and Annex C.
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//   Licensed under the Apache License, Version 2.0 (the "License");
-//   you may not use this file except in compliance with the License.
-//   You may obtain a copy of the License at
+//    The COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Affero General Public License for more details.
 //
-//   Unless required by applicable law or agreed to in writing, software
-//   distributed under the License is distributed on an "AS IS" BASIS,
-//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//   See the License for the specific language governing permissions and
-//   limitations under the License.
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @namespace COMET.Web.Common.Components.Applications
-@typeparam TViewModel where TViewModel: class, COMET.Web.Common.ViewModels.Components.Applications.IApplicationTemplateViewModel
-@inherits DisposableComponent
+@inherits GenericApplicationTemplate<COMET.Web.Common.ViewModels.Components.Applications.IApplicationTemplateViewModel>

--- a/COMET.Web.Common/Components/Applications/ApplicationTemplate.razor.cs
+++ b/COMET.Web.Common/Components/Applications/ApplicationTemplate.razor.cs
@@ -25,54 +25,43 @@
 
 namespace COMET.Web.Common.Components.Applications
 {
-    using System.ComponentModel;
+    using COMET.Web.Common.Extensions;
 
-    using COMET.Web.Common.Services.ConfigurationService;
-    using COMET.Web.Common.Utilities;
-    using COMET.Web.Common.ViewModels.Components.Applications;
-
-    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.WebUtilities;
 
     /// <summary>
-    /// Shared component that will englobe all applications
-    /// </summary>
-    /// <typeparam name="TViewModel">Any <see cref="IApplicationTemplateViewModel"/></typeparam>
-    public partial class ApplicationTemplate<TViewModel>
-    {
-        /// <summary>
-        /// Body of the application
-        /// </summary>
-        [Parameter]
-        public RenderFragment Body { get; set; }
-
-        /// <summary>
-        /// Gets or Sets the <typeparamref name="TViewModel" />
-        /// </summary>
-        [Inject]
-        public TViewModel ViewModel { get; set; }
-
-        /// <summary>
-        /// The <see cref="NavigationManager" />
-        /// </summary>
-        [Inject]
-        public NavigationManager NavigationManager { get; set; }
-
-        /// <summary>
-        /// The <see cref="IConfigurationService" />
-        /// </summary>
-        [Inject]
-        public IConfigurationService ConfigurationService { get; set; }
-
-        /// <summary>
-        /// Set URL parameters based on the current context
-        /// </summary>
-        /// <param name="currentOptions">A <see cref="Dictionary{TKey,TValue}" /> of URL parameters</param>
-        protected virtual void SetUrlParameters(Dictionary<string, string> currentOptions)
+	/// Shared component that will englobe any applications that on need to be connected to a 10-25 datasource
+	/// </summary>
+	public partial class ApplicationTemplate
+	{
+		/// <summary>
+		/// Method invoked when the component is ready to start, having received its
+		/// initial parameters from its parent in the render tree.
+		/// </summary>
+        protected override void OnInitialized()
         {
-            if (string.IsNullOrEmpty(this.ConfigurationService.ServerConfiguration.ServerAddress))
+            base.OnInitialized();
+
+            this.SetCorrectUrl();
+        }
+
+        /// <summary>
+        /// Sets the correct url based on the context
+        /// </summary>
+        internal void SetCorrectUrl()
+        {
+            var urlPage = this.NavigationManager.Uri.Replace(this.NavigationManager.BaseUri, string.Empty).Split('?')[0];
+            var currentOptions = this.NavigationManager.Uri.GetParametersFromUrl();
+            this.SetUrlParameters(currentOptions);
+            var targetOptions = new Dictionary<string, string>();
+
+            foreach (var currentOption in currentOptions.Where(x => !string.IsNullOrEmpty(x.Value)))
             {
-                currentOptions[QueryKeys.ServerKey] = this.ViewModel.SessionService.Session.DataSourceUri;
+                targetOptions[currentOption.Key] = currentOption.Value;
             }
+
+            var targetUrl = QueryHelpers.AddQueryString(urlPage, targetOptions);
+            this.NavigationManager.NavigateTo(targetUrl);
         }
     }
 }

--- a/COMET.Web.Common/Components/Applications/GenericApplicationTemplate.razor
+++ b/COMET.Web.Common/Components/Applications/GenericApplicationTemplate.razor
@@ -20,6 +20,5 @@
 //   limitations under the License.
 ------------------------------------------------------------------------------->
 @namespace COMET.Web.Common.Components.Applications
-@typeparam TThing where TThing: CDP4Common.CommonData.Thing
-@typeparam TViewModel where TViewModel: class, COMET.Web.Common.ViewModels.Components.Applications.ISingleThingApplicationTemplateViewModel<TThing>
-@inherits GenericApplicationTemplate<TViewModel>
+@typeparam TViewModel where TViewModel: class, COMET.Web.Common.ViewModels.Components.Applications.IApplicationTemplateViewModel
+@inherits DisposableComponent

--- a/COMET.Web.Common/Components/Applications/GenericApplicationTemplate.razor.cs
+++ b/COMET.Web.Common/Components/Applications/GenericApplicationTemplate.razor.cs
@@ -1,0 +1,76 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="GenericApplicationTemplate.razor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023 RHEA System S.A.
+// 
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine
+// 
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Applications
+{
+    using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.Utilities;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Shared component that will englobe all applications
+    /// </summary>
+    /// <typeparam name="TViewModel">Any <see cref="IApplicationTemplateViewModel"/></typeparam>
+    public abstract partial class GenericApplicationTemplate<TViewModel>
+    {
+        /// <summary>
+        /// Body of the application
+        /// </summary>
+        [Parameter]
+        public RenderFragment Body { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the <typeparamref name="TViewModel" />
+        /// </summary>
+        [Inject]
+        public TViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// The <see cref="NavigationManager" />
+        /// </summary>
+        [Inject]
+        public NavigationManager NavigationManager { get; set; }
+
+        /// <summary>
+        /// The <see cref="IConfigurationService" />
+        /// </summary>
+        [Inject]
+        public IConfigurationService ConfigurationService { get; set; }
+
+        /// <summary>
+        /// Set URL parameters based on the current context
+        /// </summary>
+        /// <param name="currentOptions">A <see cref="Dictionary{TKey,TValue}" /> of URL parameters</param>
+        protected virtual void SetUrlParameters(Dictionary<string, string> currentOptions)
+        {
+            if (string.IsNullOrEmpty(this.ConfigurationService.ServerConfiguration.ServerAddress))
+            {
+                currentOptions[QueryKeys.ServerKey] = this.ViewModel.SessionService.Session.DataSourceUri;
+            }
+        }
+    }
+}

--- a/COMET.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/COMET.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -100,6 +100,8 @@ namespace COMET.Web.Common.Extensions
             serviceProvider.AddScoped<IModelMenuViewModel, ModelMenuViewModel>();
             serviceProvider.AddTransient<IIterationSelectorViewModel, IterationSelectorViewModel>();
             serviceProvider.AddTransient<ISingleIterationApplicationTemplateViewModel, SingleIterationApplicationTemplateViewModel>();
+            serviceProvider.AddTransient<ISingleEngineeringModelApplicationTemplateViewModel, SingleEngineeringModelApplicationTemplateViewModel>();
+            serviceProvider.AddTransient<IApplicationTemplateViewModel, ApplicationTemplateViewModel>();
             serviceProvider.AddTransient<IPublicationsViewModel, PublicationsViewModel>();
         }
     }

--- a/COMET.Web.Common/Extensions/ThingExtensions.cs
+++ b/COMET.Web.Common/Extensions/ThingExtensions.cs
@@ -36,7 +36,7 @@ namespace COMET.Web.Common.Extensions
     /// </summary>
     public static class ThingExtensions
     {
-		/// <summary>
+        /// <summary>
         /// Gets the name of the <see cref="Iteration" />
         /// </summary>
         /// <param name="iteration">The <see cref="Iteration" /></param>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #477 
GenericApplicationTemplate created to handle the Generic (required for subcomponent) and implementation of ApplicationTemplate. The ApplicationTemplate can be used now.

Cleanup encoding and tab for ThingExtension file
<!-- Thanks for contributing to COMET-WEB! -->

