### PR TITLE
Feat/482 add specific cherrypick method

### DIFF
--- a/COMET.Web.Common.Tests/Utilities/CherryPick/CherryPickRunnerTestFixture.cs
+++ b/COMET.Web.Common.Tests/Utilities/CherryPick/CherryPickRunnerTestFixture.cs
@@ -74,11 +74,11 @@ namespace COMET.Web.Common.Tests.Utilities.CherryPick
             var engineeringModelId = Guid.NewGuid();
             var iterationId = Guid.NewGuid();
             propertyInfo?.SetValue(this.viewModel, true, null);
-            await this.viewModel.RunSingleCherryPickAsync(engineeringModelId, iterationId);
+            await this.viewModel.RunCherryPickAsync(new[] { (engineeringModelId, iterationId)});
             this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<Thing>>>()), Times.Never);
             
             propertyInfo?.SetValue(this.viewModel, false, null);
-            await this.viewModel.RunSingleCherryPickAsync(engineeringModelId, iterationId);
+            await this.viewModel.RunCherryPickAsync(new[] { (engineeringModelId, iterationId)});
             this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<Thing>>>()), Times.Once);
         }
     }

--- a/COMET.Web.Common.Tests/Utilities/CherryPick/CherryPickRunnerTestFixture.cs
+++ b/COMET.Web.Common.Tests/Utilities/CherryPick/CherryPickRunnerTestFixture.cs
@@ -28,7 +28,8 @@ namespace COMET.Web.Common.Tests.Utilities.CherryPick
 {
     using NUnit.Framework;
 
-    using CDP4Common.SiteDirectoryData;
+    using SiteDirectory = CDP4Common.SiteDirectoryData.SiteDirectory;
+    using CDP4Common.DTO;
 
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.CherryPick;
@@ -61,12 +62,24 @@ namespace COMET.Web.Common.Tests.Utilities.CherryPick
             var propertyInfo = typeof(CherryPickRunner).GetProperty("IsCherryPicking", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
 
             propertyInfo?.SetValue(this.viewModel, true, null);
-            await this.viewModel.RunCherryPick();
-            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<CDP4Common.DTO.Thing>>>()), Times.Never);
+            await this.viewModel.RunCherryPickAsync();
+            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<Thing>>>()), Times.Never);
 
             propertyInfo?.SetValue(this.viewModel, false, null);
-            await this.viewModel.RunCherryPick();
-            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<CDP4Common.DTO.Thing>>>()), Times.Once);
+            await this.viewModel.RunCherryPickAsync();
+            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<Thing>>>()), Times.Once);
+            
+            this.needCherryPickedData.Invocations.Clear();
+            
+            var engineeringModelId = Guid.NewGuid();
+            var iterationId = Guid.NewGuid();
+            propertyInfo?.SetValue(this.viewModel, true, null);
+            await this.viewModel.RunSingleCherryPickAsync(engineeringModelId, iterationId);
+            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<Thing>>>()), Times.Never);
+            
+            propertyInfo?.SetValue(this.viewModel, false, null);
+            await this.viewModel.RunSingleCherryPickAsync(engineeringModelId, iterationId);
+            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<IEnumerable<Thing>>>()), Times.Once);
         }
     }
 }

--- a/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
@@ -30,8 +30,6 @@ namespace COMET.Web.Common.Utilities.CherryPick
 
     using COMET.Web.Common.Services.SessionManagement;
 
-    using Thing = CDP4Common.DTO.Thing;
-
     /// <summary>
     /// Utility class that could run CherryPick query for <see cref="INeedCherryPickedData" />
     /// </summary>
@@ -83,8 +81,9 @@ namespace COMET.Web.Common.Utilities.CherryPick
         }
         
         /// <summary>
-        /// Runs the cherrypick features based on data required from <see cref="NeedCherryPicked" />
+        /// Runs the cherrypick features based on data required from <see cref="CherryPickRunner.NeedCherryPicked" /> and a particular set of EngineeringModelId and IterationId.
         /// </summary>
+        /// <param name="ids">A <see cref="Tuple{Guid,Guid}"/> to run the cherry pick for a particular set of engineeringModelIds and iterationIds</param>
         /// <returns>A <see cref="Task" /></returns>
         public async Task RunCherryPickAsync(IEnumerable<(Guid engineeringModelId, Guid iterationId)> ids)
         {

--- a/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
@@ -70,7 +70,7 @@ namespace COMET.Web.Common.Utilities.CherryPick
         }
         
         /// <summary>
-        /// Runs the cherrypick features based on data required from <see cref="needCherryPicked" />
+        /// Runs the cherrypick features based on data required from <see cref="needCherryPicked" /> for all the Engineering Models the user is participating on
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
         public async Task RunCherryPickAsync()

--- a/COMET.Web.Common/Utilities/CherryPick/ICherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/ICherryPickRunner.cs
@@ -42,17 +42,16 @@ namespace COMET.Web.Common.Utilities.CherryPick
         void InitializeProperties(IEnumerable<INeedCherryPickedData> needCherryPickedData);
 
         /// <summary>
-        /// Runs the cherrypick features for a specific Engineering Model and Iteration, based on data required from <see cref="NeedCherryPicked" />
-        /// </summary>
-        /// <param name="engineeringModelId">The engineering model Id that we want to cherry pick from</param>
-        /// <param name="iterationId">The iteration Id that we want to cherry pick from</param>
-        /// <returns>A <see cref="Task" /></returns>
-        Task RunSingleCherryPickAsync(Guid engineeringModelId, Guid iterationId);
-        
-        /// <summary>
-        /// Runs the cherrypick features based on data required from <see cref="CherryPickRunner.NeedCherryPicked" />
+        /// Runs the cherrypick features based on data required from &lt;see cref="CherryPickRunner.NeedCherryPicked" /&gt;
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
         Task RunCherryPickAsync();
+
+        /// <summary>
+        /// Runs the cherrypick features based on data required from <see cref="CherryPickRunner.NeedCherryPicked" /> and a particular set of EngineeringModelId and IterationId.
+        /// </summary>
+        /// <param name="ids">A <see cref="Tuple{Guid,Guid}"/> to run the cherry pick for a particular set of engineeringModelIds and iterationIds</param>
+        /// <returns>A <see cref="Task" /></returns>
+        Task RunCherryPickAsync(IEnumerable<(Guid engineeringModelId, Guid iterationId)> ids);
     }
 }

--- a/COMET.Web.Common/Utilities/CherryPick/ICherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/ICherryPickRunner.cs
@@ -38,13 +38,21 @@ namespace COMET.Web.Common.Utilities.CherryPick
         /// <summary>
         /// Initializes the internal properties
         /// </summary>
-        /// <param name="needCherryPicked">A collection of <see cref="INeedCherryPickedData"/></param>
-        void InitializeProperties(IEnumerable<INeedCherryPickedData> needCherryPicked);
+        /// <param name="needCherryPickedData">A collection of <see cref="INeedCherryPickedData"/></param>
+        void InitializeProperties(IEnumerable<INeedCherryPickedData> needCherryPickedData);
 
+        /// <summary>
+        /// Runs the cherrypick features for a specific Engineering Model and Iteration, based on data required from <see cref="NeedCherryPicked" />
+        /// </summary>
+        /// <param name="engineeringModelId">The engineering model Id that we want to cherry pick from</param>
+        /// <param name="iterationId">The iteration Id that we want to cherry pick from</param>
+        /// <returns>A <see cref="Task" /></returns>
+        Task RunSingleCherryPickAsync(Guid engineeringModelId, Guid iterationId);
+        
         /// <summary>
         /// Runs the cherrypick features based on data required from <see cref="CherryPickRunner.NeedCherryPicked" />
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
-        Task RunCherryPick();
+        Task RunCherryPickAsync();
     }
 }

--- a/COMET.Web.Common/Utilities/CherryPick/ICherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/ICherryPickRunner.cs
@@ -42,7 +42,7 @@ namespace COMET.Web.Common.Utilities.CherryPick
         void InitializeProperties(IEnumerable<INeedCherryPickedData> needCherryPickedData);
 
         /// <summary>
-        /// Runs the cherrypick features based on data required from &lt;see cref="CherryPickRunner.NeedCherryPicked" /&gt;
+        /// Runs the cherrypick features based on data required from <see cref="CherryPickRunner.NeedCherryPicked"/>;
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
         Task RunCherryPickAsync();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This provides the ability for us to specifically run a CherryPick on a particular engineering model and iteration.

@antoineatrhea This is slightly different than what we had envisioned yesterday but I felt that the code was not becoming clear enough when attempting to fuse the two methods (so that we'd have the RunCherryPick() running the RunSingleCherryPick() inside it). As such, I opted by extracting some common denominators from the logic and keeping things separate.
<!-- Thanks for contributing to COMET-WEB! -->

