### PR TITLE
Fix the CherryPickRunner to use the correct Iids

### DIFF
--- a/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
@@ -76,7 +76,7 @@ namespace COMET.Web.Common.Utilities.CherryPick
         public async Task RunCherryPickAsync()
         {
             var availableEngineeringModelSetups = this.sessionService.GetParticipantModels().ToList();
-            var engineeringModelAndIterationIdTuple = availableEngineeringModelSetups.Select(x => (x.Iid, x.IterationSetup.Single(c => c.FrozenOn == null).Iid));
+            var engineeringModelAndIterationIdTuple = availableEngineeringModelSetups.Select(x => (x.EngineeringModelIid, x.IterationSetup.Single(c => c.FrozenOn == null).IterationIid));
             await this.RunCherryPickAsync(engineeringModelAndIterationIdTuple);
         }
         


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
We were using the SetupIds instead of the Model/Iteration Ids.
<!-- Thanks for contributing to COMET-WEB! -->

