### PR TITLE
Fix #475: Added EngineeringModelId inside Template and improvement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@
 **/Dockerfile*
 **/obj
 !nginx.conf
+switcher.json

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ MigrationBackup/
 
 # Jetbrains folders
 .idea/
+
+switcher.json

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -25,7 +25,7 @@
     </PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CDP4ServicesDal-CE" Version="24.2.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="24.4.0" />
     <PackageReference Include="DevExpress.Blazor" Version="23.1.4" />
     <PackageReference Include="FluentResults" Version="3.15.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.4" />

--- a/COMET.Web.Common/Components/Applications/SingleEngineeringModelApplicationTemplate.razor
+++ b/COMET.Web.Common/Components/Applications/SingleEngineeringModelApplicationTemplate.razor
@@ -27,7 +27,7 @@
     <EngineeringModelSelector ViewModel="@this.ViewModel.EngineeringModelSelectorViewModel"/>
 </DxPopup>
 
-@if (this.ViewModel.SessionService.OpenIterations.Count == 0)
+@if (this.ViewModel.SessionService.OpenEngineeringModels.Count == 0)
 {
     <DxPopup Visible="true" HeaderText="Open a Model" ShowFooter="false" CloseOnEscape="false" CloseOnOutsideClick="false"
              ShowCloseButton="false">

--- a/COMET.Web.Common/Components/Applications/SingleIterationApplicationTemplate.razor.cs
+++ b/COMET.Web.Common/Components/Applications/SingleIterationApplicationTemplate.razor.cs
@@ -51,6 +51,7 @@ namespace COMET.Web.Common.Components.Applications
         /// </summary>
         protected override void OnInitialized()
         {
+            this.UpdateProperties();
             base.OnInitialized();
 
             this.Disposables.Add(CDPMessageBus.Current.Listen<DomainChangedEvent>()
@@ -64,7 +65,14 @@ namespace COMET.Web.Common.Components.Applications
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
+            this.UpdateProperties();
+        }
 
+        /// <summary>
+        /// Update properties of the viewmodel based on provided parameters
+        /// </summary>
+        private void UpdateProperties()
+        {
             if (this.IterationId == Guid.Empty)
             {
                 switch (this.ViewModel.SessionService.OpenIterations.Count)
@@ -79,17 +87,10 @@ namespace COMET.Web.Common.Components.Applications
             }
             else if (this.IterationId != Guid.Empty && this.ViewModel.SelectedThing == null)
             {
-                var iteration = this.ViewModel.SessionService.OpenIterations.Items.FirstOrDefault(x => x.Iid == this.IterationId);
-
-                if (iteration != null)
-                {
-                    this.ViewModel.OnThingSelect(iteration);
-                }
-                else
-                {
-                    this.IterationId = Guid.Empty;
-                }
+                this.ViewModel.OnThingSelect(this.ViewModel.SessionService.OpenIterations.Items.FirstOrDefault(x => x.Iid == this.IterationId));
             }
+
+            this.IterationId = this.ViewModel.SelectedThing?.Iid ?? Guid.Empty;
         }
 
         /// <summary>

--- a/COMET.Web.Common/ViewModels/Components/Applications/SingleIterationApplicationTemplateViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Applications/SingleIterationApplicationTemplateViewModel.cs
@@ -62,7 +62,7 @@ namespace COMET.Web.Common.ViewModels.Components.Applications
         public override void OnThingSelect(Iteration thing)
         {
             base.OnThingSelect(thing);
-            this.SelectedIterationData = new IterationData(thing.IterationSetup, true);
+            this.SelectedIterationData = thing == null ? null : new IterationData(thing.IterationSetup, true);
         }
 
         /// <summary>

--- a/COMETwebapp.Tests/Pages/ModelDashboard/ModelDashboardTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ModelDashboard/ModelDashboardTestFixture.cs
@@ -192,7 +192,7 @@ namespace COMETwebapp.Tests.Pages.ModelDashboard
                 parameters.Add(p => p.IterationId, this.secondIteration.Iid.ToShortGuid());
             });
 
-            Assert.That(this.viewModel.SelectedThing, Is.Null);
+            Assert.That(this.viewModel.SelectedThing, Is.EqualTo(this.firstIteration));
         }
     }
 }

--- a/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
@@ -201,7 +201,7 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
                 parameters.Add(p => p.IterationId, this.secondIteration.Iid.ToShortGuid());
             });
 
-            Assert.That(this.viewModel.SelectedThing, Is.Null);
+            Assert.That(this.viewModel.SelectedThing, Is.EqualTo(this.firstIteration));
         }
     }
 }

--- a/COMETwebapp.Tests/Pages/Viewer/ViewerTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/Viewer/ViewerTestFixture.cs
@@ -162,7 +162,7 @@ namespace COMETwebapp.Tests.Pages.Viewer
 
             this.context.RenderComponent<Viewer>(parameters => { parameters.Add(p => p.IterationId, this.secondIteration.Iid.ToShortGuid()); });
 
-            Assert.That(this.viewModel.SelectedThing, Is.Null);
+            Assert.That(this.viewModel.SelectedThing, Is.EqualTo(this.firstIteration));
         }
 
         [Test]

--- a/COMETwebapp.sln.DotSettings
+++ b/COMETwebapp.sln.DotSettings
@@ -252,8 +252,8 @@
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/EnableStyleCopSupport/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/ShowEditorConfigStatusBarIndicator/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">--------------------------------------------------------------------------------------------------------------------&#xD;
- &lt;copyright file="$FILENAME$" company="RHEA System S.A."&gt;&#xD;
-    Copyright (c) $CURRENT_YEAR$ RHEA System S.A.&#xD;
+ &lt;copyright file="${File.FileName}" company="RHEA System S.A."&gt;&#xD;
+    Copyright (c) ${CurrentDate.Year} RHEA System S.A.&#xD;
 &#xD;
     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine&#xD;
 &#xD;
@@ -282,6 +282,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #475 

- [x] Added parameter EngineeringModelId inside SingleEngineeringModelApplicationTemplate
- [x] Behavior improved for Single(Interation/EngineeringModel)ApplicationTemplate to set properties directly on Initialization => Possibility to not have multiple url history when preselecting the Iteration/EngineeringModel 
- [x] Test aligned with changes

<!-- Thanks for contributing to COMET-WEB! -->

