### PR TITLE
Fix/filter-empty-results-from-cherrypick-processing

### DIFF
--- a/COMET.Web.Common.Tests/Utilities/CherryPick/CherryPickRunnerTestFixture.cs
+++ b/COMET.Web.Common.Tests/Utilities/CherryPick/CherryPickRunnerTestFixture.cs
@@ -26,15 +26,20 @@
 
 namespace COMET.Web.Common.Tests.Utilities.CherryPick
 {
+    using CDP4Common.CommonData;
+    using CDP4Common.DTO;
+
     using NUnit.Framework;
 
     using SiteDirectory = CDP4Common.SiteDirectoryData.SiteDirectory;
-    using CDP4Common.DTO;
 
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.CherryPick;
 
     using Moq;
+
+    using Alias = CDP4Common.DTO.Alias;
+    using Thing = CDP4Common.DTO.Thing;
 
     [TestFixture]
     public class CherryPickRunnerTestFixture
@@ -79,7 +84,16 @@ namespace COMET.Web.Common.Tests.Utilities.CherryPick
             
             propertyInfo?.SetValue(this.viewModel, false, null);
             await this.viewModel.RunCherryPickAsync(new[] { (engineeringModelId, iterationId)});
-            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(Moq.It.IsAny<IEnumerable<Thing>>()), Times.Once);
+            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(It.IsAny<IEnumerable<Thing>>()), Times.Never);
+            
+            var mockThings = new List<Thing> { new Alias() };
+
+            this.sessionService.Setup(x => x.Session.CherryPick(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<IEnumerable<ClassKind>>(), It.IsAny<IEnumerable<Guid>>()))
+                .ReturnsAsync(mockThings);
+            
+            propertyInfo?.SetValue(this.viewModel, false, null);
+            await this.viewModel.RunCherryPickAsync(new[] { (engineeringModelId, iterationId)});
+            this.needCherryPickedData.Verify(x => x.ProcessCherryPickedData(It.IsAny<IEnumerable<Thing>>()), Times.Once);
         }
     }
 }

--- a/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
+++ b/COMET.Web.Common/Utilities/CherryPick/CherryPickRunner.cs
@@ -109,14 +109,14 @@ namespace COMET.Web.Common.Utilities.CherryPick
             var categoryIds = this.GetCategoryIdsForCherryPick();
             
             await ids.ParallelForEachAsync(async pair =>
-            {
-                var result = (await this.sessionService.Session.CherryPick(pair.engineeringModelId, pair.iterationId, classKinds, categoryIds)).ToList();
-                
-                foreach (var needCherryPickedData in this.needCherryPicked)
                 {
-                    needCherryPickedData.ProcessCherryPickedData(result);
-                }
-            },
+                    var result = (await this.sessionService.Session.CherryPick(pair.engineeringModelId, pair.iterationId, classKinds, categoryIds)).ToList();
+                    
+                    foreach (var needCherryPickedData in this.needCherryPicked.Where(needCherryPickedData => result.Any()))
+                    {
+                        needCherryPickedData.ProcessCherryPickedData(result);
+                    }
+                },
             this.numberOfThreads,
             cancellationToken);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to COMET-WEB! -->

