### PR TITLE
Exposing IReadOnlyCollection for tracked Things

### DIFF
--- a/COMET.Web.Common.Tests/Utilities/HaveObjectChangedTracking/HaveObjectChangedTrackingTestFixture.cs
+++ b/COMET.Web.Common.Tests/Utilities/HaveObjectChangedTracking/HaveObjectChangedTrackingTestFixture.cs
@@ -25,7 +25,6 @@
 
 namespace COMET.Web.Common.Tests.Utilities.HaveObjectChangedTracking
 {
-    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
 
     using CDP4Dal;
@@ -50,12 +49,6 @@ namespace COMET.Web.Common.Tests.Utilities.HaveObjectChangedTracking
             public ObjectChangedTracking(ICDPMessageBus messageBus) : base(messageBus)
             {
             }
-
-            public IReadOnlyList<Thing> AddedThingsReadOnlyList => this.AddedThings.AsReadOnly();
-
-            public IReadOnlyList<Thing> DeletedThingsReadOnlyList => this.DeletedThings.AsReadOnly();
-
-            public IReadOnlyList<Thing> UpdatedThingsReadOnlyList => this.UpdatedThings.AsReadOnly();
 
             public void Initialize(IEnumerable<Type> types)
             {
@@ -90,9 +83,9 @@ namespace COMET.Web.Common.Tests.Utilities.HaveObjectChangedTracking
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.objectChangedTracking.AddedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+                Assert.That(this.objectChangedTracking.GetAddedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetDeletedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetUpdatedThings(), Is.Empty);
             });
 
             this.objectChangedTracking.Initialize(new List<Type> { typeof(ElementBase) });
@@ -100,45 +93,45 @@ namespace COMET.Web.Common.Tests.Utilities.HaveObjectChangedTracking
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.objectChangedTracking.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
-                Assert.That(this.objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+                Assert.That(this.objectChangedTracking.GetAddedThings(), Has.Count.EqualTo(1));
+                Assert.That(this.objectChangedTracking.GetDeletedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetUpdatedThings(), Is.Empty);
             });
 
             this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Updated);
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.objectChangedTracking.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
-                Assert.That(this.objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.UpdatedThingsReadOnlyList, Has.Count.EqualTo(1));
+                Assert.That(this.objectChangedTracking.GetAddedThings(), Has.Count.EqualTo(1));
+                Assert.That(this.objectChangedTracking.GetDeletedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetUpdatedThings(), Has.Count.EqualTo(1));
             });
 
             this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Removed);
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.objectChangedTracking.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
-                Assert.That(this.objectChangedTracking.DeletedThingsReadOnlyList, Has.Count.EqualTo(1));
-                Assert.That(this.objectChangedTracking.UpdatedThingsReadOnlyList, Has.Count.EqualTo(1));
+                Assert.That(this.objectChangedTracking.GetAddedThings(), Has.Count.EqualTo(1));
+                Assert.That(this.objectChangedTracking.GetDeletedThings(), Has.Count.EqualTo(1));
+                Assert.That(this.objectChangedTracking.GetUpdatedThings(), Has.Count.EqualTo(1));
             });
 
             this.objectChangedTracking.Clear();
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.objectChangedTracking.AddedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+                Assert.That(this.objectChangedTracking.GetAddedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetDeletedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetUpdatedThings(), Is.Empty);
             });
 
             this.messageBus.SendObjectChangeEvent(new Parameter(), EventKind.Removed);
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.objectChangedTracking.AddedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.DeletedThingsReadOnlyList, Is.Empty);
-                Assert.That(this.objectChangedTracking.UpdatedThingsReadOnlyList, Is.Empty);
+                Assert.That(this.objectChangedTracking.GetAddedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetDeletedThings(), Is.Empty);
+                Assert.That(this.objectChangedTracking.GetUpdatedThings(), Is.Empty);
             });
         }
     }

--- a/COMET.Web.Common.Tests/ViewModels/Components/Applications/SingleIterationApplicationBaseViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/Applications/SingleIterationApplicationBaseViewModelTestFixture.cs
@@ -60,7 +60,7 @@ namespace COMET.Web.Common.Tests.ViewModels.Components.Applications
             {
             }
 
-            public IReadOnlyList<Thing> AddedThingsReadOnlyList => this.AddedThings.AsReadOnly();
+            public IReadOnlyList<Thing> GetAddedThings => this.AddedThings.AsReadOnly();
 
             public void Initialize(IEnumerable<Type> types)
             {
@@ -100,17 +100,17 @@ namespace COMET.Web.Common.Tests.ViewModels.Components.Applications
             var elementDefinition = new ElementDefinition { Container = new Iteration() };
 
             this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
-            Assert.That(this.viewModel.AddedThingsReadOnlyList, Is.Empty);
+            Assert.That(this.viewModel.GetAddedThings, Is.Empty);
 
             this.viewModel.CurrentThing = new Iteration { Iid = Guid.NewGuid() };
 
             this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
-            Assert.That(this.viewModel.AddedThingsReadOnlyList, Is.Empty);
+            Assert.That(this.viewModel.GetAddedThings, Is.Empty);
 
             this.viewModel.CurrentThing.Element.Add(elementDefinition);
 
             this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
-            Assert.That(this.viewModel.AddedThingsReadOnlyList, Has.Count.EqualTo(1));
+            Assert.That(this.viewModel.GetAddedThings, Has.Count.EqualTo(1));
         }
 
         [Test]

--- a/COMET.Web.Common.Tests/ViewModels/Components/Applications/SingleIterationApplicationBaseViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/Applications/SingleIterationApplicationBaseViewModelTestFixture.cs
@@ -25,7 +25,6 @@
 
 namespace COMET.Web.Common.Tests.ViewModels.Components.Applications
 {
-    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -59,8 +58,6 @@ namespace COMET.Web.Common.Tests.ViewModels.Components.Applications
             public SingleIterationApplicationViewModel(ISessionService sessionService, ICDPMessageBus messageBus) : base(sessionService, messageBus)
             {
             }
-
-            public IReadOnlyList<Thing> GetAddedThings => this.AddedThings.AsReadOnly();
 
             public void Initialize(IEnumerable<Type> types)
             {

--- a/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
+++ b/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
@@ -64,9 +64,34 @@ namespace COMET.Web.Common.Utilities.HaveObjectChangedTracking
         }
 
         /// <summary>
+        /// Gets a <see cref="IReadOnlyCollection{T}" /> of added <see cref="Thing" />s
+        /// </summary>
+        public IReadOnlyCollection<Thing> GetAddedThings => this.AddedThings;
+
+        /// <summary>
+        /// Gets a <see cref="IReadOnlyCollection{T}" /> of deleted <see cref="Thing" />s
+        /// </summary>
+        public IReadOnlyCollection<Thing> GetDeletedThings => this.DeletedThings;
+
+        /// <summary>
+        /// Gets a <see cref="IReadOnlyCollection{T}" /> of updated <see cref="Thing" />s
+        /// </summary>
+        public IReadOnlyCollection<Thing> GetUpdatedThings => this.UpdatedThings;
+
+        /// <summary>
         /// Gets the injected <see cref="ICDPMessageBus" />
         /// </summary>
         protected ICDPMessageBus MessageBus { get; }
+
+        /// <summary>
+        /// Clears all recorded changes
+        /// </summary>
+        public void ClearRecordedChanges()
+        {
+            this.DeletedThings.Clear();
+            this.UpdatedThings.Clear();
+            this.AddedThings.Clear();
+        }
 
         /// <summary>
         /// Initializes all <see cref="ObjectChangedEvent" /> subscription
@@ -79,16 +104,6 @@ namespace COMET.Web.Common.Utilities.HaveObjectChangedTracking
         {
             var observables = typesOfInterest.Select(objectChangedTypeTarget => this.MessageBus.Listen<ObjectChangedEvent>(objectChangedTypeTarget)).ToList();
             this.Disposables.Add(observables.Merge().Subscribe(this.RecordChange));
-        }
-
-        /// <summary>
-        /// Clears all recorded changes
-        /// </summary>
-        protected void ClearRecordedChanges()
-        {
-            this.DeletedThings.Clear();
-            this.UpdatedThings.Clear();
-            this.AddedThings.Clear();
         }
 
         /// <summary>

--- a/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
+++ b/COMET.Web.Common/Utilities/HaveObjectChangedTracking/HaveObjectChangedTracking.cs
@@ -64,24 +64,33 @@ namespace COMET.Web.Common.Utilities.HaveObjectChangedTracking
         }
 
         /// <summary>
+        /// Gets the injected <see cref="ICDPMessageBus" />
+        /// </summary>
+        protected ICDPMessageBus MessageBus { get; }
+
+        /// <summary>
         /// Gets a <see cref="IReadOnlyCollection{T}" /> of added <see cref="Thing" />s
         /// </summary>
-        public IReadOnlyCollection<Thing> GetAddedThings => this.AddedThings;
+        public IReadOnlyCollection<Thing> GetAddedThings()
+        {
+            return this.AddedThings;
+        }
 
         /// <summary>
         /// Gets a <see cref="IReadOnlyCollection{T}" /> of deleted <see cref="Thing" />s
         /// </summary>
-        public IReadOnlyCollection<Thing> GetDeletedThings => this.DeletedThings;
+        public IReadOnlyCollection<Thing> GetDeletedThings()
+        {
+            return this.DeletedThings;
+        }
 
         /// <summary>
         /// Gets a <see cref="IReadOnlyCollection{T}" /> of updated <see cref="Thing" />s
         /// </summary>
-        public IReadOnlyCollection<Thing> GetUpdatedThings => this.UpdatedThings;
-
-        /// <summary>
-        /// Gets the injected <see cref="ICDPMessageBus" />
-        /// </summary>
-        protected ICDPMessageBus MessageBus { get; }
+        public IReadOnlyCollection<Thing> GetUpdatedThings()
+        {
+            return this.UpdatedThings;
+        }
 
         /// <summary>
         /// Clears all recorded changes


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
In HaveObjectChangedTracking  class:
- Exposes IReadOnlyCollection
- Exposes ClearRecordedChanges method 
<!-- Thanks for contributing to COMET-WEB! -->

