### PR TITLE
Fix #523 "Add an ElementDefinition" button error in parameter editor + tooltip improvements

### DIFF
--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -40,7 +40,9 @@
 else
 {
     <div class="parameter-row-text">
-        <Tooltip MarginBottom="bottom-60 text-align-center" Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]">
+        <Tooltip MarginBottom="text-align-center" 
+                 Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
+                 CssClass="position-absolute">
             <DxTextBox Text="@this.ViewModel.ValueArray[this.ViewModel.ValueArrayIndex]"
                        InputCssClass="text-prameter-editor"
                        CssClass="parameter-input"

--- a/COMET.Web.Common/Components/Tooltip.razor
+++ b/COMET.Web.Common/Components/Tooltip.razor
@@ -21,7 +21,7 @@
 ------------------------------------------------------------------------------->
 @namespace COMET.Web.Common.Components
 
-<div class="tooltip-wrapper">
+<div class="tooltip-wrapper @(this.CssClass)">
     <span class="@(this.MarginBottom) tooltip-content">@(this.Text)</span>
     @(this.ChildContent)
 </div>

--- a/COMET.Web.Common/Components/Tooltip.razor.cs
+++ b/COMET.Web.Common/Components/Tooltip.razor.cs
@@ -49,5 +49,11 @@ namespace COMET.Web.Common.Components
         /// </summary>
         [Parameter]
         public string MarginBottom { get; set; }
+
+        /// <summary>
+        /// Define the custom css class for the component
+        /// </summary>
+        [Parameter]
+        public string CssClass { get; set; }
     }
 }

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -366,13 +366,22 @@
     border-radius: 6px;
     z-index: 1;
     font-size: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-color: transparent black transparent transparent;
+    height: fit-content;
 }
+
+    .tooltip-content:empty {
+        display: none;
+    }
 
     .tooltip-content::after {
         content: "";
         position: absolute;
         top: 50%;
         left: 0%;
+        transform: translateY(-50%);
         margin-left: -10px;
         border-width: 5px;
         border-style: solid;

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -368,7 +368,6 @@
     font-size: 14px;
     top: 50%;
     transform: translateY(-50%);
-    border-color: transparent black transparent transparent;
     height: fit-content;
 }
 

--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
@@ -100,11 +100,6 @@
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.ModelCode)" Caption="@("Model Code")" AllowGroup="false" AllowSort="true" />
             <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.OwnerName)" Caption="@("Owner")" AllowGroup="false" AllowSort="true" />
-            <DxGridCommandColumn Width="200px" EditButtonVisible="false" DeleteButtonVisible="false">
-                <HeaderTemplate>
-                    <DxButton Id="addElementButton" Text="Add an Element Definition" IconCssClass="oi oi-plus" Click="() => Grid.StartEditNewRowAsync()" />
-                </HeaderTemplate>
-            </DxGridCommandColumn>
         </Columns>
     </DxGrid>
 </div>


### PR DESCRIPTION
…p improvement

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #523 [Parameter Editor] when the user clicks on the "Add an ElementDefinition" button an unhandled error occurs #523

- Removes "add an element definition" button from parameter editor
- Tooltip improvements

