### PR TITLE
Feat #476 IHaveReusableRows interface introduced

### DIFF
--- a/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
@@ -112,6 +112,15 @@ namespace COMET.Web.Common.ViewModels.Components.Applications
         }
 
         /// <summary>
+        /// Registers viewmodels with reusable rows
+        /// </summary>
+        /// <param name="viewModels">The view models that implement <see cref="IHaveReusableRows"/></param>
+        protected void RegisterViewModelsWithReusableRows(params IHaveReusableRows[] viewModels)
+        {
+            this.RegisterViewModelsWithReusableRows(viewModels.ToList());
+        }
+
+        /// <summary>
         /// Method used to update the view model inner components that recycle rows
         /// </summary>
         protected void UpdateInnerComponents()

--- a/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
@@ -118,9 +118,9 @@ namespace COMET.Web.Common.ViewModels.Components.Applications
         {
             foreach (var viewModel in this.RegisteredViewModelsWithReusableRows)
             {
-                viewModel.AddRows(this.AddedThings);
-                viewModel.UpdateRows(this.UpdatedThings);
-                viewModel.RemoveRows(this.DeletedThings);
+                viewModel.AddRows(this.AddedThings.ToList());
+                viewModel.UpdateRows(this.UpdatedThings.ToList());
+                viewModel.RemoveRows(this.DeletedThings.ToList());
             }
         }
 

--- a/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
@@ -115,7 +115,7 @@ namespace COMET.Web.Common.ViewModels.Components.Applications
         /// Registers viewmodels with reusable rows
         /// </summary>
         /// <param name="viewModels">The view models that implement <see cref="IHaveReusableRows"/></param>
-        protected void RegisterViewModelsWithReusableRows(params IHaveReusableRows[] viewModels)
+        protected void RegisterViewModelWithReusableRows(params IHaveReusableRows[] viewModels)
         {
             this.RegisterViewModelsWithReusableRows(viewModels.ToList());
         }

--- a/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Applications/ApplicationBaseViewModel.cs
@@ -98,6 +98,33 @@ namespace COMET.Web.Common.ViewModels.Components.Applications
         }
 
         /// <summary>
+        /// Gets or sets a collection of the registered view models with reusable rows
+        /// </summary>
+        private List<IHaveReusableRows> RegisteredViewModelsWithReusableRows { get; set; } = [];
+
+        /// <summary>
+        /// Registers a collection of view models with reusable rows
+        /// </summary>
+        /// <param name="viewModels">The view models that implement <see cref="IHaveReusableRows"/></param>
+        protected void RegisterViewModelsWithReusableRows(IEnumerable<IHaveReusableRows> viewModels)
+        {
+            this.RegisteredViewModelsWithReusableRows.AddRange(viewModels.ToList());
+        }
+
+        /// <summary>
+        /// Method used to update the view model inner components that recycle rows
+        /// </summary>
+        protected void UpdateInnerComponents()
+        {
+            foreach (var viewModel in this.RegisteredViewModelsWithReusableRows)
+            {
+                viewModel.AddRows(this.AddedThings);
+                viewModel.UpdateRows(this.UpdatedThings);
+                viewModel.RemoveRows(this.DeletedThings);
+            }
+        }
+
+        /// <summary>
         /// Handles the <see cref="SessionStatus.EndUpdate" /> message received
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/COMET.Web.Common/ViewModels/Components/Applications/IHaveReusableRows.cs
+++ b/COMET.Web.Common/ViewModels/Components/Applications/IHaveReusableRows.cs
@@ -1,0 +1,52 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IHaveReusableRows.cs" company="RHEA System S.A.">
+//     Copyright (c) 2024 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Applications
+{
+    using CDP4Common.CommonData;
+
+    /// <summary>
+    /// Interface to be implemented whenever a viewmodel needs to recycle its rows
+    /// </summary>
+    public interface IHaveReusableRows
+    {
+        /// <summary>
+        /// Add rows related to <see cref="Thing" /> that has been added
+        /// </summary>
+        /// <param name="addedThings">A collection of added <see cref="Thing" /></param>
+        void AddRows(IEnumerable<Thing> addedThings);
+
+        /// <summary>
+        /// Updates rows related to <see cref="Thing" /> that have been updated
+        /// </summary>
+        /// <param name="updatedThings">A collection of updated <see cref="Thing" /></param>
+        void UpdateRows(IEnumerable<Thing> updatedThings);
+
+        /// <summary>
+        /// Remove rows related to a <see cref="Thing" /> that has been deleted
+        /// </summary>
+        /// <param name="deletedThings">A collection of deleted <see cref="Thing" /></param>
+        void RemoveRows(IEnumerable<Thing> deletedThings);
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
+    using COMET.Web.Common.ViewModels.Components.Applications;
     using COMET.Web.Common.ViewModels.Components.ParameterEditors;
 
     using DynamicData;
@@ -35,7 +36,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
     /// <summary>
     /// Interface for the <see cref="ParameterTableViewModel"/>
     /// </summary>
-    public interface IParameterTableViewModel
+    public interface IParameterTableViewModel : IHaveReusableRows
     {
         /// <summary>
         /// Gets the collection of the <see cref="ParameterBaseRowViewModel"/>
@@ -74,23 +75,5 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// <param name="selectedParameterType">The selected <see cref="ParameterType"/></param>
         /// <param name="isOwnedParameters">Value asserting that the only <see cref="Thing"/> owned by the current <see cref="DomainOfExpertise"/> should be visible</param>
         void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, ParameterType selectedParameterType, bool isOwnedParameters);
-
-        /// <summary>
-        /// Remove rows related to a <see cref="Thing"/> that has been deleted
-        /// </summary>
-        /// <param name="deletedThings">A collection of deleted <see cref="Thing"/></param>
-        void RemoveRows(IEnumerable<Thing> deletedThings);
-
-        /// <summary>
-        /// Add rows related to <see cref="Thing"/> that has been added
-        /// </summary>
-        /// <param name="addedThings">A collection of added <see cref="Thing"/></param>
-        void AddRows(IEnumerable<Thing> addedThings);
-
-        /// <summary>
-        /// Updates rows related to <see cref="Thing"/> that have been updated
-        /// </summary>
-        /// <param name="updatedThings">A collection of updated <see cref="Thing"/></param>
-        void UpdateRows(IEnumerable<Thing> updatedThings);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
@@ -78,6 +78,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 x => x.IsOwnedParameters).SubscribeAsync(_ => this.ApplyFilters()));
 
             this.InitializeSubscriptions(ObjectChangedTypesOfInterest);
+            this.RegisterViewModelsWithReusableRows([this.ParameterTableViewModel]);
         }
 
         /// <summary>
@@ -127,9 +128,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
 
             this.IsLoading = true;
             await Task.Delay(1);
-            this.ParameterTableViewModel.RemoveRows(this.DeletedThings.ToList());
-            this.ParameterTableViewModel.UpdateRows(this.UpdatedThings.ToList());
-            this.ParameterTableViewModel.AddRows(this.AddedThings.ToList());
+
+            this.UpdateInnerComponents();
             this.ClearRecordedChanges();
             this.IsLoading = false;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #476 IHaveReusableRows for VM that can recycle their rows 

- A new IHaveReusableRows has been introduced for viewmodels that need to recycle their rows
- The application base view model class has now the method "UpdateInnerComponents", that calls the methods AddRows, UpdateRows and RemoveRows from the registered viewmodels in the collection RegisteredViewModelsWithReusableRows
