### PR TITLE
Feat #474 Refactor applications based on new components

### DIFF
--- a/COMET.Web.Common/Components/Applications/SingleEngineeringModelApplicationTemplate.razor.cs
+++ b/COMET.Web.Common/Components/Applications/SingleEngineeringModelApplicationTemplate.razor.cs
@@ -82,7 +82,7 @@ namespace COMET.Web.Common.Components.Applications
             }
             else if (this.EngineeringModelId != Guid.Empty && this.ViewModel.SelectedThing == null)
             {
-                this.ViewModel.OnThingSelect(this.ViewModel.SessionService.OpenEngineeringModels.FirstOrDefault(x => x.Iid == this.EngineeringModelId));
+                this.ViewModel.OnThingSelect(this.ViewModel.SessionService.OpenEngineeringModels.FirstOrDefault(x => x.EngineeringModelSetup.Iid == this.EngineeringModelId));
             }
 
             this.EngineeringModelId = this.ViewModel.SelectedThing?.Iid ?? Guid.Empty;

--- a/COMETwebapp.Tests/Components/BookEditor/BookEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/BookEditor/BookEditorBodyTestFixture.cs
@@ -87,7 +87,6 @@ namespace COMETwebapp.Tests.Components.BookEditor
             availableBooks.Add(this.selectedBook);
 
             this.viewModel = new Mock<IBookEditorBodyViewModel>();
-            this.viewModel.Setup(x => x.CurrentDomain).Returns(new DomainOfExpertise());
             this.viewModel.Setup(x => x.AvailableBooks).Returns(availableBooks);
             this.viewModel.Setup(x => x.SelectedBook).Returns(this.selectedBook);
             this.viewModel.Setup(x => x.SelectedSection).Returns(this.selectedSection);

--- a/COMETwebapp.Tests/Components/UserManagement/UserManagementTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/UserManagement/UserManagementTableTestFixture.cs
@@ -38,6 +38,7 @@ namespace COMETwebapp.Tests.Components.UserManagement
     using CDP4Dal.Events;
     using CDP4Dal.Permission;
 
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
@@ -392,19 +393,22 @@ namespace COMETwebapp.Tests.Components.UserManagement
         {
             this.context.RenderComponent<UserManagementTable>();
 
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(2));
+
             var personTest = new Person()
             {
                 Iid = Guid.NewGuid()
             };
 
             this.messageBus.SendObjectChangeEvent(personTest, EventKind.Added);
-            this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
 
             this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Person, EventKind.Removed);
-            this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
 
             this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Person, EventKind.Updated);
-            this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
 
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(2));
         }

--- a/COMETwebapp.Tests/ViewModels/Components/BookEditor/BookEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/BookEditor/BookEditorBodyViewModelTestFixture.cs
@@ -39,7 +39,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.BookEditor
     using Moq;
 
     using NUnit.Framework;
-    using System.Runtime.Intrinsics.Arm;
 
     [TestFixture]
     public class BookEditorBodyViewModelTestFixture
@@ -59,6 +58,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.BookEditor
         [TearDown]
         public void Teardown()
         {
+            this.viewModel.Dispose();
             this.messageBus.ClearSubscriptions();
         }
 

--- a/COMETwebapp.Tests/ViewModels/Components/BookEditor/BookEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/BookEditor/BookEditorBodyViewModelTestFixture.cs
@@ -27,9 +27,11 @@ namespace COMETwebapp.Tests.ViewModels.Components.BookEditor
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
 
     using CDP4Dal;
 
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Services.SessionManagement;
 
     using COMETwebapp.ViewModels.Components.BookEditor;
@@ -37,6 +39,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.BookEditor
     using Moq;
 
     using NUnit.Framework;
+    using System.Runtime.Intrinsics.Arm;
 
     [TestFixture]
     public class BookEditorBodyViewModelTestFixture
@@ -247,6 +250,60 @@ namespace COMETwebapp.Tests.ViewModels.Components.BookEditor
                 Assert.That(this.viewModel.ThingToDelete, Is.Null);
                 Assert.That(this.viewModel.EditorPopupViewModel.IsVisible, Is.False);
             });
+        }
+
+        [Test]
+        public void VerifyOnThingChanged()
+        {
+            //Try to set a new engineering model value to the CurrentThing property
+            Assert.That(this.viewModel.CurrentThing, Is.Null);
+
+            var category = new Category()
+            {
+                Name = "category A",
+                ShortName = "catA"
+            };
+
+            var rdl = new ModelReferenceDataLibrary()
+            {
+                DefinedCategory = { category }
+            };
+
+            var activeDomain = new DomainOfExpertise()
+            {
+                Name = "tester",
+                ShortName = "tester"
+            };
+
+            var engineeringModelSetup = new EngineeringModelSetup()
+            {
+                ActiveDomain = { activeDomain },
+                RequiredRdl = { rdl }
+            };
+
+            this.viewModel.CurrentThing = new EngineeringModel()
+            {
+                EngineeringModelSetup = engineeringModelSetup
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.CurrentThing, Is.Not.Null);
+                Assert.That(this.viewModel.AvailableCategories, Contains.Item(category));
+                Assert.That(this.viewModel.ActiveDomains, Contains.Item(activeDomain));
+            });
+        }
+
+        [Test]
+        public void VerifySessionRefresh()
+        {
+            this.viewModel.CurrentThing = new EngineeringModel()
+            {
+                EngineeringModelSetup = new EngineeringModelSetup()
+            };
+
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+            Assert.That(this.viewModel.CurrentThing, Is.Not.Null);
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ElementDefinitionTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ElementDefinitionTableViewModelTestFixture.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
     using CDP4Dal;
     using CDP4Dal.Events;
 
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Services.SessionManagement;
 
     using COMETwebapp.ViewModels.Components.ModelEditor;
@@ -130,6 +131,9 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
         [Test]
         public void VerifyRecordChange()
         {
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+            Assert.That(this.viewModel.RowsSource, Has.Count.EqualTo(3));
+
             var elementDefinition = new ElementDefinition()
             {
                 Iid = Guid.NewGuid()
@@ -137,13 +141,13 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
 
             this.iteration.Element.Add(elementDefinition);
             this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
-            this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
 
             this.messageBus.SendObjectChangeEvent(this.viewModel.RowsSource[0].ElementBase, EventKind.Removed);
-            this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
 
             this.messageBus.SendObjectChangeEvent(this.viewModel.RowsSource[0].ElementBase, EventKind.Updated);
-            this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
 
             Assert.That(this.viewModel.RowsSource, Has.Count.EqualTo(3));
         }

--- a/COMETwebapp/Components/BookEditor/BookEditorBody.razor
+++ b/COMETwebapp/Components/BookEditor/BookEditorBody.razor
@@ -23,7 +23,7 @@
 @using COMETwebapp.Extensions
 @using COMET.Web.Common.Components.BookEditor
 @using CDP4Common.ReportingData
-@inherits COMET.Web.Common.Components.Applications.SingleIterationApplicationBase<COMETwebapp.ViewModels.Components.BookEditor.IBookEditorBodyViewModel>
+@inherits COMET.Web.Common.Components.Applications.SingleEngineeringModelApplicationBase<COMETwebapp.ViewModels.Components.BookEditor.IBookEditorBodyViewModel>
 
 <LoadingComponent IsVisible="this.ViewModel.IsLoading">
     

--- a/COMETwebapp/Components/UserManagement/UserManagementTable.razor
+++ b/COMETwebapp/Components/UserManagement/UserManagementTable.razor
@@ -22,7 +22,7 @@
 @using COMETwebapp.ViewModels.Components.UserManagement.Rows
 @using CDP4Common.SiteDirectoryData
 @using COMETwebapp.ViewModels.Components.UserManagement;
-@inherits COMET.Web.Common.Components.Applications.SingleIterationApplicationBase<COMETwebapp.ViewModels.Components.UserManagement.IUserManagementTableViewModel>;
+@inherits COMET.Web.Common.Components.Applications.ApplicationBase<COMETwebapp.ViewModels.Components.UserManagement.IUserManagementTableViewModel>;
 
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
     <DxGrid @ref="Grid"

--- a/COMETwebapp/Pages/BookEditor/BookEditor.razor
+++ b/COMETwebapp/Pages/BookEditor/BookEditor.razor
@@ -22,10 +22,10 @@ Copyright (c) 2023-2024 RHEA System S.A.
 @using COMETwebapp.Utilities
 @using COMETwebapp.Components.BookEditor
 @attribute [Route(WebAppConstantValues.BookEditorPage)]
-@inherits COMET.Web.Common.Pages.SingleIterationPageTemplate
+@inherits COMET.Web.Common.Pages.SingleEngineeringModelPageTemplate
 
-<SingleIterationApplicationTemplate IterationId="@this.RequestedIteration" ShowActiveModel="true">
+<SingleEngineeringModelApplicationTemplate EngineeringModelId="@this.RequestedEngineeringModel" ShowActiveModel="true">
     <Body>
     <BookEditorBody/>
     </Body>
-</SingleIterationApplicationTemplate>
+</SingleEngineeringModelApplicationTemplate>

--- a/COMETwebapp/Pages/UserManagement/UserManagementPage.razor
+++ b/COMETwebapp/Pages/UserManagement/UserManagementPage.razor
@@ -15,12 +15,12 @@ Copyright (c) 2023-2024 RHEA System S.A.
     along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @using COMETwebapp.Utilities
-@inherits COMET.Web.Common.Pages.SingleIterationPageTemplate
+@inherits COMET.Web.Common.Pages.ApplicationPageTemplate
 @attribute [Route(WebAppConstantValues.UserManagementPage)]
 @attribute [Authorize]
 
-<SingleIterationApplicationTemplate IterationId="@this.RequestedIteration" ShowActiveModel="true">
+<ApplicationTemplate>
      <Body>
          <UserManagementTable />
      </Body>
-</SingleIterationApplicationTemplate>
+</ApplicationTemplate>

--- a/COMETwebapp/ViewModels/Components/BookEditor/BookEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/BookEditor/BookEditorBodyViewModel.cs
@@ -45,7 +45,7 @@ namespace COMETwebapp.ViewModels.Components.BookEditor
     /// <summary>
     /// ViewModel for the BookEditorBody component
     /// </summary>
-    public class BookEditorBodyViewModel : SingleIterationApplicationBaseViewModel, IBookEditorBodyViewModel
+    public class BookEditorBodyViewModel : SingleEngineeringModelApplicationBaseViewModel, IBookEditorBodyViewModel
     {
         /// <summary>
         /// Backing field for the <see cref="SelectedBook"/> property
@@ -204,34 +204,31 @@ namespace COMETwebapp.ViewModels.Components.BookEditor
         }
 
         /// <summary>
-        /// Update this view model properties when the <see cref="Iteration" /> has changed
+        /// Update this view model properties when the <see cref="EngineeringModel" /> has changed
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
-        protected override async Task OnThingChanged()
+        protected override Task OnThingChanged()
         {
             this.IsLoading = true;
-            await base.OnThingChanged();
 
-            if (this.CurrentThing.Container is EngineeringModel engineeringModel)
+            this.AvailableBooks.Edit(inner =>
             {
-                this.AvailableBooks.Edit(inner =>
-                {
-                    inner.Clear();
-                    inner.AddRange(engineeringModel.Book);
-                });
+                inner.Clear();
+                inner.AddRange(this.CurrentThing.Book);
+            });
 
-                this.ActiveDomains.Clear();
-                this.ActiveDomains.AddRange(engineeringModel.EngineeringModelSetup.ActiveDomain);
+            this.ActiveDomains.Clear();
+            this.ActiveDomains.AddRange(this.CurrentThing.EngineeringModelSetup.ActiveDomain);
 
-                this.AvailableCategories.Clear();
-                var categories = engineeringModel.RequiredRdls.SelectMany(x => x.DefinedCategory);
-                this.AvailableCategories.AddRange(categories);
-            }
+            this.AvailableCategories.Clear();
+            var categories = this.CurrentThing.RequiredRdls.SelectMany(x => x.DefinedCategory);
+            this.AvailableCategories.AddRange(categories);
 
             this.EditorPopupViewModel.AvailableCategories = this.AvailableCategories;
             this.EditorPopupViewModel.ActiveDomains = this.ActiveDomains;
 
             this.IsLoading = false;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -299,7 +296,7 @@ namespace COMETwebapp.ViewModels.Components.BookEditor
             switch (this.ThingToCreate)
             {
                 case Book: 
-                    thingContainer = this.CurrentThing.Container;
+                    thingContainer = this.CurrentThing;
                     break;
                 case Section: 
                     thingContainer = this.SelectedBook;

--- a/COMETwebapp/ViewModels/Components/BookEditor/IBookEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/BookEditor/IBookEditorBodyViewModel.cs
@@ -38,7 +38,7 @@ namespace COMETwebapp.ViewModels.Components.BookEditor
     /// <summary>
     /// ViewModel for the BookEditorBody component
     /// </summary>
-    public interface IBookEditorBodyViewModel : ISingleIterationApplicationBaseViewModel
+    public interface IBookEditorBodyViewModel : ISingleEngineeringModelApplicationBaseViewModel
     {
         /// <summary>
         /// Gets or sets the current selected <see cref="Book"/>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/IElementDefinitionTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/IElementDefinitionTableViewModel.cs
@@ -39,7 +39,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
     /// <summary>
     /// Interface for the <see cref="ElementDefinitionTableViewModel" />
     /// </summary>
-    public interface IElementDefinitionTableViewModel : ISingleIterationApplicationBaseViewModel
+    public interface IElementDefinitionTableViewModel : ISingleIterationApplicationBaseViewModel, IHaveReusableRows
     {
         /// <summary>
         /// Gets the collection of the <see cref="ElementDefinitionRowViewModel" />

--- a/COMETwebapp/ViewModels/Components/ReferenceData/CategoriesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/CategoriesTableViewModel.cs
@@ -48,7 +48,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
     /// <summary>
     /// View model used to manage <see cref="Category" />
     /// </summary>
-    public class CategoriesTableViewModel : SingleIterationApplicationBaseViewModel, ICategoriesTableViewModel
+    public class CategoriesTableViewModel : ApplicationBaseViewModel, ICategoriesTableViewModel
     {
         /// <summary>
         /// Injected property to get access to <see cref="IPermissionService" />

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ICategoriesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ICategoriesTableViewModel.cs
@@ -26,18 +26,19 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
 {
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+
     using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
     using COMETwebapp.Wrappers;
-    using DevExpress.Blazor;
+
     using DynamicData;
 
     /// <summary>
     /// View model used to manage <see cref="Category" />
     /// </summary>
-    public interface ICategoriesTableViewModel : ISingleIterationApplicationBaseViewModel
+    public interface ICategoriesTableViewModel : IApplicationBaseViewModel
     {
         /// <summary>
         /// The <see cref="Category" /> to create or edit

--- a/COMETwebapp/ViewModels/Components/ReferenceData/IParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/IParameterTypeTableViewModel.cs
@@ -36,7 +36,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
     /// <summary>
     /// View model used to manage <see cref="ParameterType" />
     /// </summary>
-    public interface IParameterTypeTableViewModel : ISingleIterationApplicationBaseViewModel
+    public interface IParameterTypeTableViewModel : IApplicationBaseViewModel
     {
         /// <summary>
         /// Gets or sets the data source for the grid control.

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypeTableViewModel.cs
@@ -45,7 +45,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
     /// <summary>
     /// View model used to manage <see cref="ParameterType" />
     /// </summary>
-    public class ParameterTypeTableViewModel : SingleIterationApplicationBaseViewModel, IParameterTypeTableViewModel
+    public class ParameterTypeTableViewModel : ApplicationBaseViewModel, IParameterTypeTableViewModel
     {
         /// <summary>
         /// Injected property to get access to <see cref="IPermissionService" />

--- a/COMETwebapp/ViewModels/Components/UserManagement/IUserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/UserManagement/IUserManagementTableViewModel.cs
@@ -38,7 +38,7 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
     /// <summary>
     /// View model used to manage <see cref="Person" />
     /// </summary>
-    public interface IUserManagementTableViewModel : ISingleIterationApplicationBaseViewModel
+    public interface IUserManagementTableViewModel : IApplicationBaseViewModel
     {
         /// <summary>
         /// The <see cref="Person" /> to create

--- a/COMETwebapp/ViewModels/Components/UserManagement/IUserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/UserManagement/IUserManagementTableViewModel.cs
@@ -38,7 +38,7 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
     /// <summary>
     /// View model used to manage <see cref="Person" />
     /// </summary>
-    public interface IUserManagementTableViewModel : IApplicationBaseViewModel
+    public interface IUserManagementTableViewModel : IApplicationBaseViewModel, IHaveReusableRows
     {
         /// <summary>
         /// The <see cref="Person" /> to create

--- a/COMETwebapp/ViewModels/Components/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/UserManagement/UserManagementTableViewModel.cs
@@ -49,7 +49,7 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
     /// <summary>
     /// View model used to manage <see cref="Person" />
     /// </summary>
-    public class UserManagementTableViewModel : SingleIterationApplicationBaseViewModel, IUserManagementTableViewModel
+    public class UserManagementTableViewModel : ApplicationBaseViewModel, IUserManagementTableViewModel
     {
         /// <summary>
         /// Injected property to get access to <see cref="IPermissionService" />
@@ -346,16 +346,6 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
         protected override bool ShouldRecordChange(ObjectChangedEvent objectChangedEvent)
         {
             return true;
-        }
-
-        /// <summary>
-        /// Update this view model properties
-        /// </summary>
-        /// <returns>A <see cref="Task" /></returns>
-        protected override async Task OnThingChanged()
-        {
-            await base.OnThingChanged();
-            this.IsLoading = false;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/UserManagement/UserManagementTableViewModel.cs
@@ -79,6 +79,7 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
             this.ShowHideDeprecatedThingsService = showHideDeprecatedThingsService;
 
             this.InitializeSubscriptions(new List<Type> { typeof(Person) });
+            this.RegisterViewModelWithReusableRows(this);
         }
 
         /// <summary>
@@ -254,12 +255,12 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
         }
 
         /// <summary>
-        /// Remove rows related to a <see cref="ElementBase" /> that has been deleted
+        /// Remove rows related to a <see cref="Person" /> that has been deleted
         /// </summary>
-        /// <param name="deletedThings">A collection of deleted <see cref="ElementBase" /></param>
-        public void RemoveRows(IEnumerable<Person> deletedThings)
+        /// <param name="deletedThings">A collection of deleted <see cref="Thing" /></param>
+        public void RemoveRows(IEnumerable<Thing> deletedThings)
         {
-            foreach (var person in deletedThings)
+            foreach (var person in deletedThings.OfType<Person>())
             {
                 var row = this.Rows.Items.FirstOrDefault(x => x.Person.Iid == person.Iid);
 
@@ -271,12 +272,21 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
         }
 
         /// <summary>
-        /// Updates rows related to <see cref="ElementBase" /> that have been updated
+        /// Add rows related to <see cref="Person" /> that has been added
         /// </summary>
-        /// <param name="updatedThings">A collection of updated <see cref="ElementBase" /></param>
-        public void UpdateRows(IEnumerable<Person> updatedThings)
+        /// <param name="addedThings">A collection of added <see cref="Thing" /></param>
+        public void AddRows(IEnumerable<Thing> addedThings)
         {
-            foreach (var person in updatedThings)
+            this.Rows.AddRange(addedThings.OfType<Person>().Select(x => new PersonRowViewModel(x)));
+        }
+
+        /// <summary>
+        /// Updates rows related to <see cref="Person" /> that have been updated
+        /// </summary>
+        /// <param name="updatedThings">A collection of updated <see cref="Thing" /></param>
+        public void UpdateRows(IEnumerable<Thing> updatedThings)
+        {
+            foreach (var person in updatedThings.OfType<Person>())
             {
                 var row = this.Rows.Items.FirstOrDefault(x => x.Person.Iid == person.Iid);
 
@@ -329,10 +339,7 @@ namespace COMETwebapp.ViewModels.Components.UserManagement
             this.IsLoading = true;
             await Task.Delay(1);
 
-            this.RemoveRows(this.DeletedThings.OfType<Person>());
-            this.UpdateRows(this.UpdatedThings.OfType<Person>());
-            this.Rows.AddRange(this.AddedThings.OfType<Person>().Select(x => new PersonRowViewModel(x)));
-
+            this.UpdateInnerComponents();
             this.ClearRecordedChanges();
             this.RefreshAccessRight();
             this.IsLoading = false;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #474 Refactor applications based on new components

- Now components that dont need iteration data inherit either ApplicationBaseViewModel or SingleEngineeringModelApplicationBaseViewModel
- Fixed null CurrentThing for SingleEngineeringModelApplicationBaseViewModel
- Also, some refactor was done to include IHaveReusableRows in applications
