### PR TITLE
Feat #422 CDP4-SDK upgraded to 26.5.1 and httpclient from blazor used into the CDP4ServicesDal #422

### DIFF
--- a/COMET.Web.Common.Tests/Extensions/ServiceCollectionExtensionsTestFixture.cs
+++ b/COMET.Web.Common.Tests/Extensions/ServiceCollectionExtensionsTestFixture.cs
@@ -46,6 +46,7 @@ namespace COMET.Web.Common.Tests.Extensions
             var serviceCollection = new ServiceCollection();
             var configuration = new Mock<IConfiguration>();
             serviceCollection.AddSingleton(configuration.Object);
+            serviceCollection.AddScoped(_ => new HttpClient());
             serviceCollection.AddLogging();
             serviceCollection.RegisterCdp4CometCommonServices(globalOptions: _ => { });
             var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/COMET.Web.Common.Tests/Services/SessionManagement/AuthenticationServiceTestFixture.cs
+++ b/COMET.Web.Common.Tests/Services/SessionManagement/AuthenticationServiceTestFixture.cs
@@ -47,6 +47,7 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
         private AuthenticationDto authenticationDto;
         private Person person;
         private CDPMessageBus messageBus;
+        private HttpClient httpClient;
 
         [SetUp]
         public void SetUp()
@@ -73,18 +74,20 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
             };
 
             this.messageBus = new CDPMessageBus();
+            this.httpClient = new HttpClient();
         }
 
         [TearDown]
         public void Teardown()
         {
+            this.httpClient.Dispose();
             this.messageBus.ClearSubscriptions();
         }
 
         [Test]
         public async Task Verify_that_a_logged_in_user_can_logout()
         {
-            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus);
+            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus, this.httpClient);
 
             await authenticationService.Logout();
 
@@ -98,7 +101,7 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
 
             this.sessionService.Setup(x => x.GetSiteDirectory()).Returns((SiteDirectory)null);
 
-            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus);
+            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus, this.httpClient);
 
             var loginResult = await authenticationService.Login(this.authenticationDto);
 
@@ -114,7 +117,7 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
 
             this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
 
-            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus);
+            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus, this.httpClient);
 
             var loginResult = await authenticationService.Login(this.authenticationDto);
 
@@ -126,7 +129,7 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
         {
             this.session.Setup(x => x.Open(It.IsAny<bool>())).Throws(new DalReadException());
 
-            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus);
+            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus, this.httpClient);
 
             var authentication = new AuthenticationDto
             {
@@ -145,7 +148,7 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
         {
             this.session.Setup(x => x.Open(It.IsAny<bool>())).Throws(new DalReadException());
 
-            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus);
+            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus, this.httpClient);
 
             var loginResult = await authenticationService.Login(this.authenticationDto);
 
@@ -157,7 +160,7 @@ namespace COMET.Web.Common.Tests.Services.SessionManagement
         {
             this.authenticationDto.SourceAddress = null;
 
-            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus);
+            var authenticationService = new AuthenticationService(this.sessionService.Object, this.cometWebAuthStateProvider, this.messageBus, this.httpClient);
 
             var loginResult = await authenticationService.Login(this.authenticationDto);
 

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-	<PackageReference Include="CDP4ServicesDal-CE" Version="26.3.0" />
+	<PackageReference Include="CDP4ServicesDal-CE" Version="26.5.1" />
     <PackageReference Include="DevExpress.Blazor" Version="23.2.3" />
     <PackageReference Include="FluentResults" Version="3.15.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.2" />

--- a/COMET.Web.Common/Services/SessionManagement/AuthenticationService.cs
+++ b/COMET.Web.Common/Services/SessionManagement/AuthenticationService.cs
@@ -58,6 +58,11 @@ namespace COMET.Web.Common.Services.SessionManagement
         private readonly ICDPMessageBus messageBus;
 
         /// <summary>
+        /// The <see cref="HttpClient" /> used to retrieve data
+        /// </summary>
+        private readonly HttpClient httpClient;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationService" /> class.
         /// </summary>
         /// <param name="sessionService">
@@ -67,11 +72,13 @@ namespace COMET.Web.Common.Services.SessionManagement
         /// The (injected) <see cref="AuthenticationStateProvider" />
         /// </param>
         /// <param name="messageBus">The <see cref="ICDPMessageBus"/></param>
-        public AuthenticationService(ISessionService sessionService, AuthenticationStateProvider authenticationStateProvider, ICDPMessageBus messageBus)
+        /// <param name="httpClient">The <see cref="HttpClient"/></param>
+        public AuthenticationService(ISessionService sessionService, AuthenticationStateProvider authenticationStateProvider, ICDPMessageBus messageBus, HttpClient httpClient)
         {
             this.messageBus = messageBus;
             this.authStateProvider = authenticationStateProvider;
             this.sessionService = sessionService;
+            this.httpClient = httpClient;
         }
 
         /// <summary>
@@ -88,7 +95,7 @@ namespace COMET.Web.Common.Services.SessionManagement
             if (authenticationDto.SourceAddress != null)
             {
                 var uri = new Uri(authenticationDto.SourceAddress);
-                var dal = new CdpServicesDal();
+                var dal = new CdpServicesDal(this.httpClient);
                 var credentials = new Credentials(authenticationDto.UserName, authenticationDto.Password, uri);
 
                 this.sessionService.Session = new Session(dal, credentials, this.messageBus);


### PR DESCRIPTION
…Dal constructor

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [ ] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Closes #422 upgrade to CDP4-SDK 26.5.1 and use the httpclient from blazor to inject into the CDP4ServicesDal

