### PR TITLE
Feat #536 [Reference Data] Measurement Units - display

### DIFF
--- a/COMETwebapp.Tests/Components/ReferenceData/MeasurementUnitsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/MeasurementUnitsTableTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="MeasurementUnitsTableTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2023-2024 RHEA System S.A.
 //
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 //
 //    This file is part of CDP4-COMET WEB Community Edition
 //    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/COMETwebapp.Tests/Components/ReferenceData/MeasurementUnitsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/MeasurementUnitsTableTestFixture.cs
@@ -1,0 +1,160 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementUnitsTableTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.ReferenceData
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Bunit;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.ReferenceData;
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DevExpress.Blazor;
+
+    using DynamicData;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using TestContext = Bunit.TestContext;
+
+    [TestFixture]
+    public class MeasurementUnitsTableTestFixture
+    {
+        private TestContext context;
+        private Mock<IMeasurementUnitsTableViewModel> viewModel;
+        private Mock<IShowHideDeprecatedThingsService> showHideService;
+        private MeasurementUnit measurementUnit1;
+        private MeasurementUnit measurementUnit2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new TestContext();
+
+            this.viewModel = new Mock<IMeasurementUnitsTableViewModel>();
+            this.showHideService = new Mock<IShowHideDeprecatedThingsService>();
+            this.showHideService.Setup(x => x.ShowDeprecatedThings).Returns(true);
+
+            this.measurementUnit1 = new SimpleUnit()
+            {
+                Name = "A name",
+                ShortName = "AName",
+                Container = new SiteReferenceDataLibrary(){ ShortName = "rdl" },
+                IsDeprecated = false
+            };
+
+            this.measurementUnit2 = new SimpleUnit()
+            {
+                Name = "B name",
+                ShortName = "BName",
+                Container = new SiteReferenceDataLibrary() { ShortName = "rdl" },
+                IsDeprecated = true
+            };
+
+            var rows = new SourceList<MeasurementUnitRowViewModel>();
+            rows.Add(new MeasurementUnitRowViewModel(this.measurementUnit1));
+            rows.Add(new MeasurementUnitRowViewModel(this.measurementUnit2));
+
+            this.viewModel.Setup(x => x.Rows).Returns(rows);
+            this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
+            this.viewModel.Setup(x => x.IsOnDeprecationMode).Returns(true);
+            this.viewModel.Setup(x => x.MeasurementUnit).Returns(new SimpleUnit());
+
+            this.context.Services.AddSingleton(this.viewModel.Object);
+            this.context.ConfigureDevExpressBlazor();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+            this.context.Dispose();
+        }
+
+        [Test]
+        public void VerifyOnInitialized()
+        {
+            var renderer = this.context.RenderComponent<MeasurementUnitsTable>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Instance.ShouldCreateMeasurementUnit, Is.EqualTo(false));
+                Assert.That(renderer.Instance.ViewModel, Is.Not.Null);
+                Assert.That(renderer.Markup, Does.Contain(this.measurementUnit1.Name));
+                Assert.That(renderer.Markup, Does.Contain(this.measurementUnit2.Name));
+                this.viewModel.Verify(x => x.InitializeViewModel(), Times.Once);
+            });
+        }
+
+        [Test]
+        public async Task VerifyDeprecatingAndUndeprecatingMeasurementUnit()
+        {
+            var renderer = this.context.RenderComponent<MeasurementUnitsTable>();
+
+            var deprecateButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "deprecateButton");
+            await renderer.InvokeAsync(deprecateButton.Instance.Click.InvokeAsync);
+            this.viewModel.Verify(x => x.OnDeprecateUnDeprecateButtonClick(It.IsAny<MeasurementUnitRowViewModel>()), Times.Once);
+
+            var unDeprecateButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "undeprecateButton");
+            await renderer.InvokeAsync(unDeprecateButton.Instance.Click.InvokeAsync);
+            this.viewModel.Verify(x => x.OnDeprecateUnDeprecateButtonClick(It.IsAny<MeasurementUnitRowViewModel>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public async Task VerifyAddingOrEditingMeasurementUnit()
+        {
+            var renderer = this.context.RenderComponent<MeasurementUnitsTable>();
+
+            var addMeasurementUnitButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addMeasurementUnitButton");
+            await renderer.InvokeAsync(addMeasurementUnitButton.Instance.Click.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Instance.ShouldCreateMeasurementUnit, Is.EqualTo(true));
+                Assert.That(this.viewModel.Object.MeasurementUnit, Is.InstanceOf(typeof(MeasurementUnit)));
+            });
+            
+            var editMeasurementUnitButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "editUnitButton");
+            await renderer.InvokeAsync(editMeasurementUnitButton.Instance.Click.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Instance.ShouldCreateMeasurementUnit, Is.EqualTo(false));
+                Assert.That(this.viewModel.Object.MeasurementUnit, Is.InstanceOf(typeof(MeasurementUnit)));
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
@@ -2,7 +2,7 @@
 //  <copyright file="MeasurementUnitsTableViewModelTestFixture.cs" company="RHEA System S.A.">
 //     Copyright (c) 2023-2024 RHEA System S.A.
 // 
-//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 // 
 //     This file is part of CDP4-COMET WEB Community Edition
 //     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-//  <copyright file="    public class MeasurementUnitsTableViewModelTestFixture.cs" company="RHEA System S.A.">
+//  <copyright file="MeasurementUnitsTableViewModelTestFixture.cs" company="RHEA System S.A.">
 //     Copyright (c) 2023-2024 RHEA System S.A.
 // 
 //     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
@@ -1,0 +1,204 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="    public class MeasurementUnitsTableViewModelTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023-2024 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using CDP4Dal.Permission;
+
+    using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData;
+
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MeasurementUnitsTableViewModelTestFixture
+    {
+        private MeasurementUnitsTableViewModel viewModel;
+        private Mock<ISessionService> sessionService;
+        private Mock<IPermissionService> permissionService;
+        private Mock<ILogger<MeasurementUnitsTableViewModel>> loggerMock;
+        private CDPMessageBus messageBus;
+        private Mock<IShowHideDeprecatedThingsService> showHideService;
+        private MeasurementUnit measurementUnit;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.sessionService = new Mock<ISessionService>();
+            this.permissionService = new Mock<IPermissionService>();
+            this.showHideService = new Mock<IShowHideDeprecatedThingsService>();
+            this.loggerMock = new Mock<ILogger<MeasurementUnitsTableViewModel>>();
+
+            this.measurementUnit = new SimpleUnit()
+            {
+                ShortName = "unit",
+                Name = "unit"
+            };
+
+            var siteReferenceDataLibrary = new SiteReferenceDataLibrary()
+            {
+                ShortName = "rdl",
+            };
+
+            var siteDirectory = new SiteDirectory()
+            {
+                ShortName = "siteDirectory"
+            };
+
+            siteReferenceDataLibrary.Unit.Add(this.measurementUnit);
+            siteDirectory.SiteReferenceDataLibrary.Add(siteReferenceDataLibrary);
+
+            this.permissionService.Setup(x => x.CanWrite(ClassKind.MeasurementUnit, this.measurementUnit.Container)).Returns(true);
+            var session = new Mock<ISession>();
+            session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+            this.messageBus = new CDPMessageBus();
+
+            this.viewModel = new MeasurementUnitsTableViewModel(this.sessionService.Object, this.showHideService.Object, this.messageBus, this.loggerMock.Object);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.messageBus.ClearSubscriptions();
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyInitializeViewModel()
+        {
+            this.viewModel.InitializeViewModel();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Rows.Count, Is.EqualTo(1));
+                Assert.That(this.viewModel.Rows.Items.First().MeasurementUnit, Is.EqualTo(this.measurementUnit));
+            });
+        }
+
+        [Test]
+        public void VerifyMeasurementUnitRowProperties()
+        {
+            this.viewModel.InitializeViewModel();
+            var measurementUnitRow = this.viewModel.Rows.Items.First();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(measurementUnitRow.ContainerName, Is.EqualTo("rdl"));
+                Assert.That(measurementUnitRow.Name, Is.EqualTo(this.measurementUnit.Name));
+                Assert.That(measurementUnitRow.ShortName, Is.EqualTo(this.measurementUnit.ShortName));
+                Assert.That(measurementUnitRow.MeasurementUnit, Is.EqualTo(this.measurementUnit));
+                Assert.That(measurementUnitRow.IsAllowedToWrite, Is.EqualTo(true));
+                Assert.That(measurementUnitRow.Type, Is.EqualTo(nameof(SimpleUnit)));
+            });
+        }
+
+        [Test]
+        public void VerifySessionRefresh()
+        {
+            this.viewModel.InitializeViewModel();
+
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+
+            var siteReferenceDataLibrary = new SiteReferenceDataLibrary()
+            {
+                ShortName = "newShortname"
+            };
+
+            var personTest = new SimpleUnit()
+            {
+                Iid = Guid.NewGuid(),
+                Container = siteReferenceDataLibrary
+            };
+
+            this.messageBus.SendObjectChangeEvent(personTest, EventKind.Added);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().MeasurementUnit, EventKind.Removed);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().MeasurementUnit, EventKind.Updated);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+
+            this.messageBus.SendObjectChangeEvent(siteReferenceDataLibrary, EventKind.Updated);
+            this.messageBus.SendObjectChangeEvent(new PersonRole(), EventKind.Updated);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Rows.Items.First().ContainerName, Is.EqualTo(siteReferenceDataLibrary.ShortName));
+                this.permissionService.Verify(x => x.CanWrite(ClassKind.MeasurementUnit, It.IsAny<Thing>()), Times.AtLeast(this.viewModel.Rows.Count));
+            });
+        }
+        
+        [Test]
+         public async Task VerifyRowOperations()
+         {
+             this.viewModel.InitializeViewModel();
+             var measurementUnitRow = this.viewModel.Rows.Items.First();
+             measurementUnitRow.IsDeprecated = false;
+
+             Assert.Multiple(() =>
+             {
+                 Assert.That(measurementUnitRow, Is.Not.Null);
+                 Assert.That(this.viewModel.IsOnDeprecationMode, Is.EqualTo(false));
+             });
+
+             this.viewModel.OnDeprecateUnDeprecateButtonClick(measurementUnitRow);
+
+             Assert.Multiple(() =>
+             {
+                 Assert.That(this.viewModel.IsOnDeprecationMode, Is.EqualTo(true));
+                 Assert.That(this.viewModel.MeasurementUnit, Is.EqualTo(measurementUnitRow.MeasurementUnit));
+             });
+             
+             this.viewModel.OnCancelPopupButtonClick();
+             Assert.That(this.viewModel.IsOnDeprecationMode, Is.EqualTo(false));
+
+             await this.viewModel.OnConfirmPopupButtonClick();
+             this.sessionService.Verify(x => x.UpdateThings(It.IsAny<SiteDirectory>(), It.Is<MeasurementUnit>(c => c.IsDeprecated == true)));
+
+             this.viewModel.MeasurementUnit.IsDeprecated = true;
+             await this.viewModel.OnConfirmPopupButtonClick();
+             this.sessionService.Verify(x => x.UpdateThings(It.IsAny<SiteDirectory>(), It.Is<MeasurementUnit>(c => c.IsDeprecated == false)));
+        }
+    }
+}

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
@@ -1,6 +1,6 @@
 ﻿<!------------------------------------------------------------------------------
 Copyright (c) 2023-2024 RHEA System S.A.
-    Authors: Justine Veirier d'aiguebonne, Sam Gerené, Alex Vorobiev, Alexander van Delft, Nabil Abbar
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
     This file is part of CDP4-COMET WEB Community Edition
      The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
@@ -15,6 +15,7 @@ Copyright (c) 2023-2024 RHEA System S.A.
     along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @using COMETwebapp.ViewModels.Components.ReferenceData.Rows
+@using CDP4Common.SiteDirectoryData
 @inherits DisposableComponent
 
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
@@ -25,9 +26,11 @@ Copyright (c) 2023-2024 RHEA System S.A.
             ShowAllRows="true"
             SearchBoxNullText="Search for a measurement unit ..."
             PopupEditFormCssClass="pw-800"
-            PopupEditFormHeaderText="Create Measurement Unit"
+            PopupEditFormHeaderText="Create Measurement Unit (UNDER DEV)"
+            CustomizeElement="DisableDeprecatedMeasurementUnit"
             EditMode="GridEditMode.PopupEditForm"
-            CustomizeElement="DisableDeprecatedMeasurementUnit">
+            EditModelSaving="@(this.OnEditMeasurementUnitSaving)"
+            CustomizeEditModel="this.CustomizeEditMeasurementUnit">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.Name)" MinWidth="150" />
             <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false" />
@@ -41,18 +44,42 @@ Copyright (c) 2023-2024 RHEA System S.A.
                 <CellDisplayTemplate>
                     @{
                         var row = (MeasurementUnitRowViewModel)context.DataItem;
+
+                        <DxButton Id="editUnitButton" Text="Edit" Click="@(() => this.Grid.StartEditRowAsync(context.VisibleIndex))" Enabled="@(row.IsAllowedToWrite)" />
+
                         if (row.IsDeprecated)
                         {
-                            <DxButton Id="undeprecateButton" Text="Un-deprecate" Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick((MeasurementUnitRowViewModel)context.DataItem)" Enabled=row.IsAllowedToWrite />
+                            <DxButton Id="undeprecateButton" Text="Un-deprecate" Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick((MeasurementUnitRowViewModel)context.DataItem)" Enabled="@(row.IsAllowedToWrite)" />
                         }
                         else
                         {
-                            <DxButton Id="deprecateButton" Text="Deprecate" Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick((MeasurementUnitRowViewModel)context.DataItem)" Enabled=row.IsAllowedToWrite />
+                            <DxButton Id="deprecateButton" Text="Deprecate" Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick((MeasurementUnitRowViewModel)context.DataItem)" Enabled="@(row.IsAllowedToWrite)" />
                         }
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
         </Columns>
+        
+        <EditFormTemplate Context="EditFormContext">
+            <DxFormLayout CssClass="w-100">
+                <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementUnit.ShortName" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementUnit.Name" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Library:" ColSpanMd="10">
+                    <DxComboBox Data="@this.ViewModel.ReferenceDataLibraries"
+                                TextFieldName="@nameof(ReferenceDataLibrary.Name)"
+                                @bind-Value="@this.ViewModel.MeasurementUnit.Container"
+                                CssClass="cw-480" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
+                    <DxCheckBox @bind-Checked="@this.ViewModel.MeasurementUnit.IsDeprecated" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+        </EditFormTemplate>
+
     </DxGrid>
     
     <DxPopup @bind-Visible="@this.ViewModel.IsOnDeprecationMode" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
@@ -1,0 +1,65 @@
+﻿<!------------------------------------------------------------------------------
+Copyright (c) 2023-2024 RHEA System S.A.
+    Authors: Justine Veirier d'aiguebonne, Sam Gerené, Alex Vorobiev, Alexander van Delft, Nabil Abbar
+    This file is part of CDP4-COMET WEB Community Edition
+     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+@using COMETwebapp.ViewModels.Components.ReferenceData.Rows
+@inherits DisposableComponent
+
+<LoadingComponent IsVisible="@this.ViewModel.IsLoading">
+    <DxGrid @ref="this.Grid"
+            Data="this.ViewModel.Rows.Items"
+            ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
+            ShowSearchBox="true"
+            ShowAllRows="true"
+            SearchBoxNullText="Search for a measurement unit ..."
+            PopupEditFormCssClass="pw-800"
+            PopupEditFormHeaderText="Create Measurement Unit"
+            EditMode="GridEditMode.PopupEditForm"
+            CustomizeElement="DisableDeprecatedMeasurementUnit">
+        <Columns>
+            <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.Name)" MinWidth="150" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.Type)" Caption="Type" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.ContainerName)" Caption="Container RDL" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.IsDeprecated)" UnboundType="GridUnboundColumnType.Boolean" Visible="false" Caption="Is Deprecated" MinWidth="80" SearchEnabled="false" />
+            <DxGridCommandColumn Width="200px" EditButtonVisible="false">
+                <HeaderTemplate>
+                    <DxButton Id="addMeasurementUnitButton" Text="Add Measurement Unit" IconCssClass="oi oi-plus" Click="() => this.Grid.StartEditNewRowAsync()"/>
+                </HeaderTemplate>
+                <CellDisplayTemplate>
+                    @{
+                        var row = (MeasurementUnitRowViewModel)context.DataItem;
+                        if (row.IsDeprecated)
+                        {
+                            <DxButton Id="undeprecateButton" Text="Un-deprecate" Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick((MeasurementUnitRowViewModel)context.DataItem)" Enabled=row.IsAllowedToWrite />
+                        }
+                        else
+                        {
+                            <DxButton Id="deprecateButton" Text="Deprecate" Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick((MeasurementUnitRowViewModel)context.DataItem)" Enabled=row.IsAllowedToWrite />
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridCommandColumn>
+        </Columns>
+    </DxGrid>
+    
+    <DxPopup @bind-Visible="@this.ViewModel.IsOnDeprecationMode" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
+        @this.ViewModel.PopupDialog
+        <div class="dxbl-grid-confirm-dialog-buttons">
+            <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@this.ViewModel.OnCancelPopupButtonClick" />
+            <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@this.ViewModel.OnConfirmPopupButtonClick" />
+        </div>
+    </DxPopup>
+</LoadingComponent>

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor.cs
@@ -1,0 +1,126 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementUnitsTable.razor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar, João Rua
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.ReferenceData
+{
+    using System.Threading.Tasks;
+
+    using COMETwebapp.ViewModels.Components.ReferenceData;
+
+    using DevExpress.Blazor;
+
+    using DynamicData;
+
+    using Microsoft.AspNetCore.Components;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Support class for the <see cref="MeasurementUnitsTable"/>
+    /// </summary>
+    public partial class MeasurementUnitsTable
+    {
+        /// <summary>
+        ///     The <see cref="IMeasurementUnitsTableViewModel" /> for this component
+        /// </summary>
+        [Inject]
+        public IMeasurementUnitsTableViewModel ViewModel { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the grid control that is being customized.
+        /// </summary>
+        private IGrid Grid { get; set; }
+
+        /// <summary>
+        /// Method invoked to highlight deprecated measurement units
+        /// </summary>
+        /// <param name="e">A <see cref="GridCustomizeElementEventArgs"/> </param>
+        private static void DisableDeprecatedMeasurementUnit(GridCustomizeElementEventArgs e)
+        {
+            if (e.ElementType == GridElementType.DataRow && (bool)e.Grid.GetRowValue(e.VisibleIndex, "IsDeprecated"))
+            {
+                e.CssClass = "highlighted-item";
+            }
+        }
+
+        /// <summary>
+        /// Method invoked to "Show/Hide Deprecated Items" 
+        /// </summary>
+        public void HideOrShowDeprecatedItems()
+        {
+            if (this.ViewModel.ShowHideDeprecatedThingsService.ShowDeprecatedThings)
+            {
+                this.Grid.ClearFilter();
+            }
+            else
+            {
+                this.Grid.FilterBy("IsDeprecated", GridFilterRowOperatorType.Equal, false);
+            }
+        }
+
+        /// <summary>
+        /// Method invoked when the component is ready to start, having received its
+        /// initial parameters from its parent in the render tree.
+        /// Override this method if you will perform an asynchronous operation and
+        /// want the component to refresh when that operation is completed.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing any asynchronous operation.</returns>
+        protected override async Task OnInitializedAsync()
+        {
+            await this.ViewModel.OnInitializedAsync();
+
+            this.Disposables.Add(this.ViewModel.Rows.CountChanged.Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+            this.Disposables.Add(this.ViewModel.Rows.Connect().AutoRefresh().Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
+            await base.OnInitializedAsync();
+        }
+
+        /// <summary>
+        /// Method invoked after each time the component has been rendered. Note that the component does
+        /// not automatically re-render after the completion of any returned <see cref="Task"/>, because
+        /// that would cause an infinite render loop.
+        /// </summary>
+        /// <param name="firstRender">
+        /// Set to <c>true</c> if this is the first time <see cref="ComponentBase.OnAfterRender(bool)"/> has been invoked
+        /// on this component instance; otherwise <c>false</c>.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing any asynchronous operation.</returns>
+        /// <remarks>
+        /// The <see cref="ComponentBase.OnAfterRender(bool)"/> and <see cref="OnAfterRenderAsync(bool)"/> lifecycle methods
+        /// are useful for performing interop, or interacting with values received from <c>@ref</c>.
+        /// Use the <paramref name="firstRender"/> parameter to ensure that initialization work is only performed
+        /// once.
+        /// </remarks>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            if (firstRender)
+            {
+                this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.ShowHideDeprecatedThingsService.ShowDeprecatedThings)
+                .Subscribe(_ => this.HideOrShowDeprecatedItems()));
+            }
+        }
+    }
+}

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor.cs
@@ -139,7 +139,6 @@ namespace COMETwebapp.Components.ReferenceData
             if (!this.ShouldCreateMeasurementUnit)
             {
                 // update measurement unit
-                return;
             }
 
             // create measurement unit

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor.cs
@@ -2,7 +2,7 @@
 // <copyright file="MeasurementUnitsTable.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2023-2024 RHEA System S.A.
 //
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar, João Rua
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 //
 //    This file is part of CDP4-COMET WEB Community Edition
 //    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
@@ -61,18 +61,6 @@ namespace COMETwebapp.Components.ReferenceData
         /// Gets or sets the grid control that is being customized.
         /// </summary>
         private IGrid Grid { get; set; }
-
-        /// <summary>
-        /// Method invoked to highlight deprecated measurement units
-        /// </summary>
-        /// <param name="e">A <see cref="GridCustomizeElementEventArgs"/> </param>
-        private static void DisableDeprecatedMeasurementUnit(GridCustomizeElementEventArgs e)
-        {
-            if (e.ElementType == GridElementType.DataRow && (bool)e.Grid.GetRowValue(e.VisibleIndex, "IsDeprecated"))
-            {
-                e.CssClass = "highlighted-item";
-            }
-        }
 
         /// <summary>
         /// Method invoked to "Show/Hide Deprecated Items" 
@@ -142,6 +130,18 @@ namespace COMETwebapp.Components.ReferenceData
             }
 
             // create measurement unit
+        }
+
+        /// <summary>
+        /// Method invoked to highlight deprecated measurement units
+        /// </summary>
+        /// <param name="e">A <see cref="GridCustomizeElementEventArgs"/> </param>
+        private static void DisableDeprecatedMeasurementUnit(GridCustomizeElementEventArgs e)
+        {
+            if (e.ElementType == GridElementType.DataRow && (bool)e.Grid.GetRowValue(e.VisibleIndex, "IsDeprecated"))
+            {
+                e.CssClass = "highlighted-item";
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
+++ b/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ namespace COMETwebapp.Extensions
             serviceCollection.AddTransient<ISystemRepresentationBodyViewModel, SystemRepresentationBodyViewModel>();
             serviceCollection.AddTransient<IElementDefinitionTableViewModel, ElementDefinitionTableViewModel>();
             serviceCollection.AddTransient<IBookEditorBodyViewModel, BookEditorBodyViewModel>();
+            serviceCollection.AddTransient<IMeasurementUnitsTableViewModel, MeasurementUnitsTableViewModel>();
         }
     }
 }

--- a/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
+++ b/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@
 //  <copyright file="ServiceCollectionExtensions.cs" company="RHEA System S.A.">
 //     Copyright (c) 2024 RHEA System S.A.
 // 
-//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 // 
 //     This file is part of CDP4-COMET WEB Community Edition
 //     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor
+++ b/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor
@@ -1,6 +1,6 @@
 ﻿<!------------------------------------------------------------------------------
 Copyright (c) 2023-2024 RHEA System S.A.
-    Authors: Justine Veirier d'aiguebonne, Sam Gerené, Alex Vorobiev, Alexander van Delft, Nabil Abbar
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
     This file is part of CDP4-COMET WEB Community Edition
      The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or

--- a/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor
+++ b/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor
@@ -21,6 +21,7 @@ Copyright (c) 2023-2024 RHEA System S.A.
 <DxToolbar ItemClick="@this.OnItemClick">
     <Items>
         <DxToolbarItem Name="ParameterTypes" Text="Parameter Types" Tooltip="Parameter Types" />
+        <DxToolbarItem Name="MeasurementUnits" Text="Measurement Units" Tooltip="Measurement Units" />
         <DxToolbarItem Name="Categories" Text="Categories" Tooltip="Categories" />
     </Items>
 </DxToolbar>
@@ -32,5 +33,8 @@ Copyright (c) 2023-2024 RHEA System S.A.
         break;
     case "Categories":
         <CategoriesTable />
+        break;
+    case "MeasurementUnits":
+        <MeasurementUnitsTable />
         break;
 }

--- a/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor.cs
+++ b/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor.cs
@@ -2,7 +2,7 @@
 // <copyright file="ReferenceDataPage.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2023-2024 RHEA System S.A.
 //
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 //
 //    This file is part of CDP4-COMET WEB Community Edition
 //    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementUnitsTableViewModel.cs
@@ -1,0 +1,97 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IMeasurementUnitsTableViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar, João Rua
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DynamicData;
+
+    /// <summary>
+    /// View model used to manage <see cref="MeasurementUnit" />s
+    /// </summary>
+    public interface IMeasurementUnitsTableViewModel : IApplicationBaseViewModel
+    {
+        /// <summary>
+        /// Gets or sets the data source for the grid control.
+        /// </summary>
+        SourceList<MeasurementUnit> DataSource { get; }
+
+        /// <summary>
+        /// A reactive collection of <see cref="MeasurementUnitRowViewModel" />
+        /// </summary>
+        SourceList<MeasurementUnitRowViewModel> Rows { get; }
+
+        /// <summary>
+        /// Injected property to get access to <see cref="IShowHideDeprecatedThingsService" />
+        /// </summary>
+        IShowHideDeprecatedThingsService ShowHideDeprecatedThingsService { get; }
+
+        /// <summary>
+        /// The <see cref="MeasurementUnit" /> to create or edit
+        /// </summary>
+        MeasurementUnit MeasurementUnit { get; set; }
+
+        /// <summary>
+        /// Indicates if confirmation popup is visible
+        /// </summary>
+        bool IsOnDeprecationMode { get; set; }
+
+        /// <summary>
+        /// popup message dialog
+        /// </summary>
+        string PopupDialog { get; set; }
+
+        /// <summary>
+        /// Method invoked when the component is ready to start, having received its
+        /// initial parameters from its parent in the render tree.
+        /// Override this method if you will perform an asynchronous operation and
+        /// want the component to refresh when that operation is completed.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing any asynchronous operation.</returns>
+        Task OnInitializedAsync();
+
+        /// <summary>
+        /// Method invoked when confirming the deprecation/un-deprecation of a <see cref="MeasurementUnitsTableViewModel.MeasurementUnit" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        Task OnConfirmPopupButtonClick();
+
+        /// <summary>
+        /// Method invoked when canceling the deprecation/un-deprecation of a <see cref="MeasurementUnitsTableViewModel.MeasurementUnit" />
+        /// </summary>
+        void OnCancelPopupButtonClick();
+
+        /// <summary>
+        /// Action invoked when the deprecate or undeprecate button is clicked
+        /// </summary>
+        /// <param name="measurementUnitRow"> The <see cref="MeasurementUnitRowViewModel" /> to deprecate or undeprecate </param>
+        void OnDeprecateUnDeprecateButtonClick(MeasurementUnitRowViewModel measurementUnitRow);
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementUnitsTableViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="IMeasurementUnitsTableViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2023-2024 RHEA System S.A.
 //
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar, João Rua
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 //
 //    This file is part of CDP4-COMET WEB Community Edition
 //    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementUnitsTableViewModel.cs
@@ -36,7 +36,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
     /// <summary>
     /// View model used to manage <see cref="MeasurementUnit" />s
     /// </summary>
-    public interface IMeasurementUnitsTableViewModel : IApplicationBaseViewModel
+    public interface IMeasurementUnitsTableViewModel : IApplicationBaseViewModel, IHaveReusableRows
     {
         /// <summary>
         /// Gets or sets the data source for the grid control.
@@ -69,13 +69,9 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
         string PopupDialog { get; set; }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// Override this method if you will perform an asynchronous operation and
-        /// want the component to refresh when that operation is completed.
+        /// Available <see cref="ReferenceDataLibrary" />s
         /// </summary>
-        /// <returns>A <see cref="Task" /> representing any asynchronous operation.</returns>
-        Task OnInitializedAsync();
+        IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; set; }
 
         /// <summary>
         /// Method invoked when confirming the deprecation/un-deprecation of a <see cref="MeasurementUnitsTableViewModel.MeasurementUnit" />
@@ -93,5 +89,19 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
         /// </summary>
         /// <param name="measurementUnitRow"> The <see cref="MeasurementUnitRowViewModel" /> to deprecate or undeprecate </param>
         void OnDeprecateUnDeprecateButtonClick(MeasurementUnitRowViewModel measurementUnitRow);
+
+        /// <summary>
+        /// Method invoked when the component is ready to start, having received its
+        /// initial parameters from its parent in the render tree.
+        /// Override this method if you will perform an asynchronous operation and
+        /// want the component to refresh when that operation is completed.
+        /// </summary>
+        void InitializeViewModel();
+
+        /// <summary>
+        /// Tries to deprecate or undeprecate a <see cref="MeasurementUnitsTableViewModel.MeasurementUnit" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        Task DeprecatingOrUnDeprecatingMeasurementUnit();
     }
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="MeasurementUnitsTableViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2023-2024 RHEA System S.A.
 //
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar, João Rua
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 //
 //    This file is part of CDP4-COMET WEB Community Edition
 //    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
@@ -181,26 +181,6 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
         }
 
         /// <summary>
-        /// Handles the refresh of the current <see cref="ISession" />
-        /// </summary>
-        /// <returns>A <see cref="Task" /></returns>
-        protected override Task OnSessionRefreshed()
-        {
-            if (this.AddedThings.Count == 0 && this.UpdatedThings.Count == 0 && this.DeletedThings.Count == 0)
-            {
-                return Task.CompletedTask;
-            }
-
-            this.IsLoading = true;
-            this.UpdateInnerComponents();
-            this.RefreshAccessRight();
-            this.ClearRecordedChanges();
-            this.IsLoading = false;
-
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
         /// Tries to deprecate or undeprecate a <see cref="MeasurementUnit" />
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
@@ -218,40 +198,6 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
             {
                 this.logger.LogError(exception, "An error has occurred while trying to deprecating or un-deprecating the measurement unit {unitName}", clonedMeasurementUnit.ShortName);
             }
-        }
-
-        /// <summary>
-        /// Refresh the displayed container name for the measurement unit rows
-        /// </summary>
-        /// <param name="rdl">
-        /// The updated <see cref="ReferenceDataLibrary" />.
-        /// </param>
-        private void RefreshContainerName(ReferenceDataLibrary rdl)
-        {
-            this.IsLoading = true;
-            var rowsContainedByUpdatedRdl = this.Rows.Items.Where(x => x.MeasurementUnit.Container.Iid == rdl.Iid);
-
-            foreach (var measurementUnit in rowsContainedByUpdatedRdl)
-            {
-                measurementUnit.ContainerName = rdl.ShortName;
-            }
-
-            this.IsLoading = false;
-        }
-
-        /// <summary>
-        /// Updates the active user access rights
-        /// </summary>
-        private void RefreshAccessRight()
-        {
-            this.IsLoading = true;
-
-            foreach (var row in this.Rows.Items)
-            {
-                row.IsAllowedToWrite = this.permissionService.CanWrite(ClassKind.MeasurementUnit, row.MeasurementUnit.Container);
-            }
-
-            this.IsLoading = false;
         }
 
         /// <summary>
@@ -307,6 +253,60 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
             var rowsToDelete = this.Rows.Items.Where(x => measurementUnitsIidsToRemove.Contains(x.MeasurementUnit.Iid)).ToList();
 
             this.Rows.RemoveMany(rowsToDelete);
+        }
+
+        /// <summary>
+        /// Handles the refresh of the current <see cref="ISession" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override Task OnSessionRefreshed()
+        {
+            if (this.AddedThings.Count == 0 && this.UpdatedThings.Count == 0 && this.DeletedThings.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            this.IsLoading = true;
+            this.UpdateInnerComponents();
+            this.RefreshAccessRight();
+            this.ClearRecordedChanges();
+            this.IsLoading = false;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Refresh the displayed container name for the measurement unit rows
+        /// </summary>
+        /// <param name="rdl">
+        /// The updated <see cref="ReferenceDataLibrary" />.
+        /// </param>
+        private void RefreshContainerName(ReferenceDataLibrary rdl)
+        {
+            this.IsLoading = true;
+            var rowsContainedByUpdatedRdl = this.Rows.Items.Where(x => x.MeasurementUnit.Container.Iid == rdl.Iid);
+
+            foreach (var measurementUnit in rowsContainedByUpdatedRdl)
+            {
+                measurementUnit.ContainerName = rdl.ShortName;
+            }
+
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Updates the active user access rights
+        /// </summary>
+        private void RefreshAccessRight()
+        {
+            this.IsLoading = true;
+
+            foreach (var row in this.Rows.Items)
+            {
+                row.IsAllowedToWrite = this.permissionService.CanWrite(ClassKind.MeasurementUnit, row.MeasurementUnit.Container);
+            }
+
+            this.IsLoading = false;
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModel.cs
@@ -276,11 +276,15 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
             var updatedPersonRoles = updatedThingsList.OfType<PersonRole>();
             var updatedRdls = updatedThingsList.OfType<ReferenceDataLibrary>();
 
-            foreach (var updatedMeasurementUnit in updatedMeasurementUnits)
+            this.Rows.Edit(action =>
             {
-                var updatedRow = new MeasurementUnitRowViewModel(updatedMeasurementUnit);
-                this.Rows.Items.First(x => x.MeasurementUnit.Iid == updatedMeasurementUnit.Iid).UpdateProperties(updatedRow);
-            }
+                foreach (var updatedMeasurementUnit in updatedMeasurementUnits)
+                {
+                    var updatedRow = new MeasurementUnitRowViewModel(updatedMeasurementUnit);
+                    var rowToUpdate = this.Rows.Items.First(x => x.MeasurementUnit.Iid == updatedMeasurementUnit.Iid);
+                    action.Replace(rowToUpdate, updatedRow);
+                }
+            });
 
             foreach (var rdl in updatedRdls)
             {
@@ -299,7 +303,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData
         /// <param name="deletedThings">A collection of deleted <see cref="Thing" /></param>
         public void RemoveRows(IEnumerable<Thing> deletedThings)
         {
-            var measurementUnitsIidsToRemove = deletedThings.OfType<MeasurementUnit>().ToList().Select(x => x.Iid);
+            var measurementUnitsIidsToRemove = deletedThings.OfType<MeasurementUnit>().Select(x => x.Iid);
             var rowsToDelete = this.Rows.Items.Where(x => measurementUnitsIidsToRemove.Contains(x.MeasurementUnit.Iid)).ToList();
 
             this.Rows.RemoveMany(rowsToDelete);

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModel.cs
@@ -1,0 +1,367 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementUnitsTableViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Nabil Abbar, João Rua
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData
+{
+    using System.Reactive.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using CDP4Dal.Permission;
+
+    using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DynamicData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// View model used to manage <see cref="MeasurementUnit" />s
+    /// </summary>
+    public class MeasurementUnitsTableViewModel : ApplicationBaseViewModel, IMeasurementUnitsTableViewModel
+    {
+        /// <summary>
+        /// Injected property to get access to <see cref="IPermissionService" />
+        /// </summary>
+        private readonly IPermissionService permissionService;
+
+        /// <summary>
+        /// Injected property to get access to <see cref="ISessionService" />
+        /// </summary>
+        private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// Backing field for <see cref="IsOnDeprecationMode" />
+        /// </summary>
+        private bool isOnDeprecationMode;
+
+        /// <summary>
+        /// A collection of all <see cref="MeasurementUnitRowViewModel" />
+        /// </summary>
+        private IEnumerable<MeasurementUnitRowViewModel> allRows = new List<MeasurementUnitRowViewModel>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeasurementUnitsTableViewModel" /> class.
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /></param>
+        /// <param name="showHideDeprecatedThingsService">The <see cref="IShowHideDeprecatedThingsService" /></param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus"/></param>
+        public MeasurementUnitsTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus) : base(sessionService, messageBus)
+        {
+            this.sessionService = sessionService;
+            this.permissionService = sessionService.Session.PermissionService;
+            this.ShowHideDeprecatedThingsService = showHideDeprecatedThingsService;
+
+            this.Disposables.Add(
+                this.MessageBus.Listen<ObjectChangedEvent>(typeof(MeasurementUnit))
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.sessionService.Session.Assembler.Cache)
+                    .Select(x => x.ChangedThing as MeasurementUnit)
+                    .SubscribeAsync(this.AddNewMeasurementUnit));
+
+            this.Disposables.Add(
+                this.MessageBus.Listen<ObjectChangedEvent>(typeof(MeasurementUnit))
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.sessionService.Session.Assembler.Cache)
+                    .Select(x => x.ChangedThing as MeasurementUnit)
+                    .SubscribeAsync(this.UpdateMeasurementUnit));
+
+            this.Disposables.Add(
+                this.MessageBus.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.sessionService.Session.Assembler.Cache)
+                    .Select(x => x.ChangedThing as ReferenceDataLibrary)
+                    .SubscribeAsync(this.RefreshContainerName));
+
+            this.Disposables.Add(this.MessageBus.Listen<ObjectChangedEvent>(typeof(PersonRole))
+                .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                       objectChange.ChangedThing.Cache == this.sessionService.Session.Assembler.Cache)
+                .Select(x => x.ChangedThing as PersonRole)
+                .SubscribeAsync(_ => this.RefreshAccessRight()));
+        }
+
+        /// <summary>
+        /// The <see cref="MeasurementUnit" /> to create or edit
+        /// </summary>
+        public MeasurementUnit MeasurementUnit { get; set; }
+
+        /// <summary>
+        /// Available <see cref="ReferenceDataLibrary" />s
+        /// </summary>
+        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; set; }
+
+        /// <summary>
+        /// Injected property to get access to <see cref="IShowHideDeprecatedThingsService" />
+        /// </summary>
+        public IShowHideDeprecatedThingsService ShowHideDeprecatedThingsService { get; }
+
+        /// <summary>
+        /// A reactive collection of <see cref="MeasurementUnitRowViewModel" />
+        /// </summary>
+        public SourceList<MeasurementUnitRowViewModel> Rows { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the data source for the grid control.
+        /// </summary>
+        public SourceList<MeasurementUnit> DataSource { get; } = new();
+
+        /// <summary>
+        /// Indicates if confirmation popup is visible
+        /// </summary>
+        public bool IsOnDeprecationMode
+        {
+            get => this.isOnDeprecationMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnDeprecationMode, value);
+        }
+
+        /// <summary>
+        /// popup message dialog
+        /// </summary>
+        public string PopupDialog { get; set; }
+
+        /// <summary>
+        /// Method invoked when the component is ready to start, having received its
+        /// initial parameters from its parent in the render tree.
+        /// Override this method if you will perform an asynchronous operation and
+        /// want the component to refresh when that operation is completed.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing any asynchronous operation.</returns>
+        public async Task OnInitializedAsync()
+        {
+            foreach (var referenceDataLibrary in this.sessionService.Session.RetrieveSiteDirectory().AvailableReferenceDataLibraries())
+            {
+                this.DataSource.AddRange(referenceDataLibrary.Unit);
+            }
+
+            this.ReferenceDataLibraries = this.sessionService.Session.RetrieveSiteDirectory().AvailableReferenceDataLibraries();
+            await this.UpdateProperties(this.DataSource.Items);
+            await this.RefreshAccessRight();
+        }
+
+        /// <summary>
+        /// Adds a new <see cref="MeasurementUnit" />
+        /// </summary>
+        public Task AddNewMeasurementUnit(MeasurementUnit measurementUnit)
+        {
+            var newRows = new List<MeasurementUnitRowViewModel>(this.allRows)
+            {
+                new(measurementUnit)
+            };
+
+            this.UpdateRows(newRows);
+
+            return this.RefreshAccessRight();
+        }
+
+        /// <summary>
+        /// Updates the <see cref="MeasurementUnit" />
+        /// </summary>
+        public Task UpdateMeasurementUnit(MeasurementUnit measurementUnit)
+        {
+            var updatedRows = new List<MeasurementUnitRowViewModel>(this.allRows);
+            var index = updatedRows.FindIndex(x => x.MeasurementUnit.Iid == measurementUnit.Iid);
+            updatedRows[index] = new MeasurementUnitRowViewModel(measurementUnit);
+            this.UpdateRows(updatedRows);
+
+            return this.RefreshAccessRight();
+        }
+
+        /// <summary>
+        /// Updates this view model properties
+        /// </summary>
+        /// <param name="measurementUnits">A collection of <see cref="MeasurementUnit" /></param>
+        public async Task UpdateProperties(IEnumerable<MeasurementUnit> measurementUnits)
+        {
+            this.IsLoading = true;
+            await Task.Delay(1);
+            this.allRows = measurementUnits.Select(x => new MeasurementUnitRowViewModel(x));
+            this.UpdateRows(this.allRows);
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Method invoked when confirming the deprecation/un-deprecation of a <see cref="MeasurementUnit" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task OnConfirmPopupButtonClick()
+        {
+            if (this.MeasurementUnit.IsDeprecated)
+            {
+                await this.UnDeprecatingMeasurementUnit();
+            }
+            else
+            {
+                await this.DeprecatingMeasurementUnit();
+            }
+
+            this.IsOnDeprecationMode = false;
+        }
+
+        /// <summary>
+        /// Method invoked when canceling the deprecation/un-deprecation of a <see cref="MeasurementUnit" />
+        /// </summary>
+        public void OnCancelPopupButtonClick()
+        {
+            this.IsOnDeprecationMode = false;
+        }
+
+        /// <summary>
+        /// Action invoked when the deprecate or undeprecate button is clicked
+        /// </summary>
+        /// <param name="measurementUnitRow"> The <see cref="MeasurementUnitRowViewModel" /> to deprecate or undeprecate </param>
+        public void OnDeprecateUnDeprecateButtonClick(MeasurementUnitRowViewModel measurementUnitRow)
+        {
+            this.MeasurementUnit = measurementUnitRow.MeasurementUnit;
+            this.PopupDialog = this.MeasurementUnit.IsDeprecated ? "You are about to un-deprecate the measurement unit: " + measurementUnitRow.Name : "You are about to deprecate the measurement unit: " + measurementUnitRow.Name;
+            this.IsOnDeprecationMode = true;
+        }
+
+        /// <summary>
+        /// Handles the refresh of the current <see cref="ISession" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnSessionRefreshed()
+        {
+            this.IsLoading = true;
+            await Task.Delay(1);
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Tries to undeprecate a <see cref="MeasurementUnit" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task UnDeprecatingMeasurementUnit()
+        {
+            var measurementUnitsToUnDeprecate = new List<MeasurementUnit>();
+            var clonedMeasurementUnit = this.MeasurementUnit.Clone(false);
+            clonedMeasurementUnit.IsDeprecated = false;
+            measurementUnitsToUnDeprecate.Add(clonedMeasurementUnit);
+
+            try
+            {
+                await this.sessionService.UpdateThings(this.sessionService.GetSiteDirectory(), measurementUnitsToUnDeprecate);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception.Message);
+                throw;
+            }
+
+            this.IsOnDeprecationMode = false;
+        }
+
+        /// <summary>
+        /// Tries to deprecate a <see cref="MeasurementUnit" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task DeprecatingMeasurementUnit()
+        {
+            var measurementUnitsToDeprecate = new List<MeasurementUnit>();
+            var clonedMeasurementUnit = this.MeasurementUnit.Clone(false);
+            clonedMeasurementUnit.IsDeprecated = true;
+            measurementUnitsToDeprecate.Add(clonedMeasurementUnit);
+
+            try
+            {
+                await this.sessionService.UpdateThings(this.sessionService.GetSiteDirectory(), measurementUnitsToDeprecate);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception.Message);
+                throw;
+            }
+
+            this.IsOnDeprecationMode = false;
+        }
+
+        /// <summary>
+        /// Refresh the displayed container name for the measurement unit rows
+        /// </summary>
+        /// <param name="rdl">
+        /// The updated <see cref="ReferenceDataLibrary" />.
+        /// </param>
+        private async Task RefreshContainerName(ReferenceDataLibrary rdl)
+        {
+            this.IsLoading = true;
+            await Task.Delay(1);
+
+            foreach (var measurementUnit in this.Rows.Items)
+            {
+                if (measurementUnit.ContainerName != rdl.ShortName)
+                {
+                    measurementUnit.ContainerName = rdl.ShortName;
+                }
+            }
+
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Updates the active user access rights
+        /// </summary>
+        private async Task RefreshAccessRight()
+        {
+            this.IsLoading = true;
+            await Task.Delay(1);
+
+            foreach (var row in this.Rows.Items)
+            {
+                row.IsAllowedToWrite = this.permissionService.CanWrite(ClassKind.MeasurementUnit, row.MeasurementUnit.Container);
+            }
+
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Update the <see cref="Rows" /> collection based on a collection of
+        /// <see cref="MeasurementUnitRowViewModel" /> to display.
+        /// </summary>
+        /// <param name="rowsToDisplay">A collection of <see cref="MeasurementUnitRowViewModel" /></param>
+        private void UpdateRows(IEnumerable<MeasurementUnitRowViewModel> rowsToDisplay)
+        {
+            rowsToDisplay = rowsToDisplay.ToList();
+
+            var deletedRows = this.Rows.Items.Where(x => rowsToDisplay.All(r => r.MeasurementUnit.Iid != x.MeasurementUnit.Iid)).ToList();
+            var addedRows = rowsToDisplay.Where(x => this.Rows.Items.All(r => r.MeasurementUnit.Iid != x.MeasurementUnit.Iid)).ToList();
+            var existingRows = rowsToDisplay.Where(x => this.Rows.Items.Any(r => r.MeasurementUnit.Iid == x.MeasurementUnit.Iid)).ToList();
+
+            this.Rows.RemoveMany(deletedRows);
+            this.Rows.AddRange(addedRows);
+
+            foreach (var existingRow in existingRows)
+            {
+                this.Rows.Items.First(x => x.MeasurementUnit.Iid == existingRow.MeasurementUnit.Iid).UpdateProperties(existingRow);
+            }
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementUnitRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementUnitRowViewModel.cs
@@ -1,0 +1,153 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MeasurementUnitRowViewModel.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023-2024 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData.Rows
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Row View Model for  <see cref="CDP4Common.SiteDirectoryData.MeasurementUnit" />
+    /// </summary>
+    public class MeasurementUnitRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="ContainerName" />
+        /// </summary>
+        private string containerName;
+
+        /// <summary>
+        /// Backing field for <see cref="IsDeprecated" />
+        /// </summary>
+        private bool isDeprecated;
+
+        /// <summary>
+        /// Backing field for <see cref="Name" />
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// Backing field for <see cref="ShortName" />
+        /// </summary>
+        private string shortName;
+
+        /// <summary>
+        /// Backing field for <see cref="Type" />
+        /// </summary>
+        private string type;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeasurementUnitRowViewModel" /> class.
+        /// </summary>
+        /// <param name="measurementUnit">The associated <see cref="MeasurementUnit" /></param>
+        public MeasurementUnitRowViewModel(MeasurementUnit measurementUnit)
+        {
+            this.MeasurementUnit = measurementUnit;
+            this.Name = measurementUnit.Name;
+            this.ShortName = measurementUnit.ShortName;
+            this.Type = measurementUnit.ClassKind.ToString();
+            var container = (ReferenceDataLibrary)measurementUnit.Container;
+            this.ContainerName = container.ShortName;
+            this.IsDeprecated = measurementUnit.IsDeprecated;
+        }
+
+        /// <summary>
+        /// The associated <see cref="MeasurementUnit" />
+        /// </summary>
+        public MeasurementUnit MeasurementUnit { get; private set; }
+
+        /// <summary>
+        /// The name of the <see cref="MeasurementUnit" />
+        /// </summary>
+        public string Name
+        {
+            get => this.name;
+            set => this.RaiseAndSetIfChanged(ref this.name, value);
+        }
+
+        /// <summary>
+        /// The short name of the <see cref="MeasurementUnit" />
+        /// </summary>
+        public string ShortName
+        {
+            get => this.shortName;
+            set => this.RaiseAndSetIfChanged(ref this.shortName, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CDP4Common.SiteDirectoryData.MeasurementUnit" /> type
+        /// </summary>
+        public string Type
+        {
+            get => this.type;
+            set => this.RaiseAndSetIfChanged(ref this.type, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CDP4Common.SiteDirectoryData.MeasurementUnit" /> container name
+        /// </summary>
+        public string ContainerName
+        {
+            get => this.containerName;
+            set => this.RaiseAndSetIfChanged(ref this.containerName, value);
+        }
+
+        /// <summary>
+        /// Value indicating if the <see cref="CDP4Common.SiteDirectoryData.MeasurementUnit" /> is deprecated
+        /// </summary>
+        public bool IsDeprecated
+        {
+            get => this.isDeprecated;
+            set => this.RaiseAndSetIfChanged(ref this.isDeprecated, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="IsAllowedToWrite" />
+        /// </summary>
+        private bool isAllowedToWrite;
+
+        /// <summary>
+        /// Value indicating if the <see cref="CDP4Common.SiteDirectoryData.MeasurementUnit" /> is deprecated
+        /// </summary>
+        public bool IsAllowedToWrite
+        {
+            get => this.isAllowedToWrite;
+            set => this.RaiseAndSetIfChanged(ref this.isAllowedToWrite, value);
+        }
+
+        /// <summary>
+        /// Update this row view model properties
+        /// </summary>
+        /// <param name="measurementUnitRow">The <see cref="MeasurementUnitRowViewModel" /> to use for updating</param>
+        public void UpdateProperties(MeasurementUnitRowViewModel measurementUnitRow)
+        {
+            this.Name = measurementUnitRow.Name;
+            this.ShortName = measurementUnitRow.ShortName;
+            this.Type = measurementUnitRow.Type;
+            this.ContainerName = measurementUnitRow.ContainerName;
+            this.IsDeprecated = measurementUnitRow.IsDeprecated;
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementUnitRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementUnitRowViewModel.cs
@@ -2,7 +2,7 @@
 //  <copyright file="MeasurementUnitRowViewModel.cs" company="RHEA System S.A.">
 //     Copyright (c) 2023-2024 RHEA System S.A.
 // 
-//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
 // 
 //     This file is part of CDP4-COMET WEB Community Edition
 //     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementUnitRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementUnitRowViewModel.cs
@@ -136,18 +136,5 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Rows
             get => this.isAllowedToWrite;
             set => this.RaiseAndSetIfChanged(ref this.isAllowedToWrite, value);
         }
-
-        /// <summary>
-        /// Update this row view model properties
-        /// </summary>
-        /// <param name="measurementUnitRow">The <see cref="MeasurementUnitRowViewModel" /> to use for updating</param>
-        public void UpdateProperties(MeasurementUnitRowViewModel measurementUnitRow)
-        {
-            this.Name = measurementUnitRow.Name;
-            this.ShortName = measurementUnitRow.ShortName;
-            this.Type = measurementUnitRow.Type;
-            this.ContainerName = measurementUnitRow.ContainerName;
-            this.IsDeprecated = measurementUnitRow.IsDeprecated;
-        }
     }
 }

--- a/WebAppHeader.DotSettings
+++ b/WebAppHeader.DotSettings
@@ -3,7 +3,7 @@
  &lt;copyright file="${File.FileName}" company="RHEA System S.A."&gt;&#xD;
     Copyright (c) ${CurrentDate.Year} RHEA System S.A.&#xD;
 &#xD;
-    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine&#xD;
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua&#xD;
 &#xD;
     This file is part of COMET WEB Community Edition&#xD;
     The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.&#xD;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #536 [Reference Data] Measurement Units - display

- Added deprecate/undeprecate functionalities
- Table rows are reactive to session events
- Placeholders created for further create/edit features

