### PR TITLE
Feat #542 [Reference Data] Measurement Scales - display

### DIFF
--- a/COMETwebapp.Tests/Components/ReferenceData/MeasurementScalesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/MeasurementScalesTableTestFixture.cs
@@ -1,0 +1,167 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementScalesTableTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.ReferenceData
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Bunit;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.ReferenceData;
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DevExpress.Blazor;
+
+    using DynamicData;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using TestContext = Bunit.TestContext;
+
+    [TestFixture]
+    public class MeasurementScalesTableTestFixture
+    {
+        private TestContext context;
+        private Mock<IMeasurementScalesTableViewModel> viewModel;
+        private Mock<IShowHideDeprecatedThingsService> showHideService;
+        private MeasurementScale measurementScale1;
+        private MeasurementScale measurementScale2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new TestContext();
+
+            this.viewModel = new Mock<IMeasurementScalesTableViewModel>();
+            this.showHideService = new Mock<IShowHideDeprecatedThingsService>();
+            this.showHideService.Setup(x => x.ShowDeprecatedThings).Returns(true);
+
+            this.measurementScale1 = new OrdinalScale()
+            {
+                Name = "A name",
+                ShortName = "AName",
+                Container = new SiteReferenceDataLibrary(){ ShortName = "rdl" },
+                Unit = new SimpleUnit() { ShortName = "unit1" },
+                NumberSet = NumberSetKind.NATURAL_NUMBER_SET,
+                IsDeprecated = false
+            };
+
+            this.measurementScale2 = new OrdinalScale()
+            {
+                Name = "B name",
+                ShortName = "BName",
+                Container = new SiteReferenceDataLibrary() { ShortName = "rdl" },
+                Unit = new SimpleUnit(){ ShortName = "unit2" },
+                NumberSet = NumberSetKind.INTEGER_NUMBER_SET,
+                IsDeprecated = true
+            };
+
+            var rows = new SourceList<MeasurementScaleRowViewModel>();
+            rows.Add(new MeasurementScaleRowViewModel(this.measurementScale1));
+            rows.Add(new MeasurementScaleRowViewModel(this.measurementScale2));
+
+            this.viewModel.Setup(x => x.Rows).Returns(rows);
+            this.viewModel.Setup(x => x.MeasurementUnits).Returns([]);
+            this.viewModel.Setup(x => x.NumberSetKinds).Returns([]);
+            this.viewModel.Setup(x => x.ReferenceDataLibraries).Returns([]);
+            this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
+            this.viewModel.Setup(x => x.IsOnDeprecationMode).Returns(true);
+            this.viewModel.Setup(x => x.MeasurementScale).Returns(new OrdinalScale());
+
+            this.context.Services.AddSingleton(this.viewModel.Object);
+            this.context.ConfigureDevExpressBlazor();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+            this.context.Dispose();
+        }
+
+        [Test]
+        public void VerifyOnInitialized()
+        {
+            var renderer = this.context.RenderComponent<MeasurementScalesTable>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Instance.ShouldCreateMeasurementScale, Is.EqualTo(false));
+                Assert.That(renderer.Instance.ViewModel, Is.Not.Null);
+                Assert.That(renderer.Markup, Does.Contain(this.measurementScale1.Name));
+                Assert.That(renderer.Markup, Does.Contain(this.measurementScale2.Name));
+                this.viewModel.Verify(x => x.InitializeViewModel(), Times.Once);
+            });
+        }
+
+        [Test]
+        public async Task VerifyDeprecatingAndUndeprecatingMeasurementScale()
+        {
+            var renderer = this.context.RenderComponent<MeasurementScalesTable>();
+
+            var deprecateButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "deprecateButton");
+            await renderer.InvokeAsync(deprecateButton.Instance.Click.InvokeAsync);
+            this.viewModel.Verify(x => x.OnDeprecateUnDeprecateButtonClick(It.IsAny<MeasurementScaleRowViewModel>()), Times.Once);
+
+            var unDeprecateButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "undeprecateButton");
+            await renderer.InvokeAsync(unDeprecateButton.Instance.Click.InvokeAsync);
+            this.viewModel.Verify(x => x.OnDeprecateUnDeprecateButtonClick(It.IsAny<MeasurementScaleRowViewModel>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public async Task VerifyAddingOrEditingMeasurementScale()
+        {
+            var renderer = this.context.RenderComponent<MeasurementScalesTable>();
+
+            var addMeasurementScaleButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addMeasurementScaleButton");
+            await renderer.InvokeAsync(addMeasurementScaleButton.Instance.Click.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Instance.ShouldCreateMeasurementScale, Is.EqualTo(true));
+                Assert.That(this.viewModel.Object.MeasurementScale, Is.InstanceOf(typeof(MeasurementScale)));
+            });
+            
+            var editMeasurementScaleButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "editScaleButton");
+            await renderer.InvokeAsync(editMeasurementScaleButton.Instance.Click.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Instance.ShouldCreateMeasurementScale, Is.EqualTo(false));
+                Assert.That(this.viewModel.Object.MeasurementScale, Is.InstanceOf(typeof(MeasurementScale)));
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModelTestFixture.cs
@@ -1,0 +1,208 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MeasurementScalesTableViewModelTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023-2024 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using CDP4Dal.Permission;
+
+    using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData;
+
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MeasurementScalesTableViewModelTestFixture
+    {
+        private MeasurementScalesTableViewModel viewModel;
+        private Mock<ISessionService> sessionService;
+        private Mock<IPermissionService> permissionService;
+        private Mock<ILogger<MeasurementScalesTableViewModel>> loggerMock;
+        private CDPMessageBus messageBus;
+        private Mock<IShowHideDeprecatedThingsService> showHideService;
+        private MeasurementScale measurementScale;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.sessionService = new Mock<ISessionService>();
+            this.permissionService = new Mock<IPermissionService>();
+            this.showHideService = new Mock<IShowHideDeprecatedThingsService>();
+            this.loggerMock = new Mock<ILogger<MeasurementScalesTableViewModel>>();
+
+            this.measurementScale = new OrdinalScale()
+            {
+                ShortName = "scale",
+                Name = "scale",
+                Unit = new SimpleUnit(){ ShortName = "simpleUnit" },
+                NumberSet = NumberSetKind.INTEGER_NUMBER_SET
+            };
+
+            var siteReferenceDataLibrary = new SiteReferenceDataLibrary()
+            {
+                ShortName = "rdl",
+            };
+
+            var siteDirectory = new SiteDirectory()
+            {
+                ShortName = "siteDirectory"
+            };
+
+            siteReferenceDataLibrary.Scale.Add(this.measurementScale);
+            siteDirectory.SiteReferenceDataLibrary.Add(siteReferenceDataLibrary);
+
+            this.permissionService.Setup(x => x.CanWrite(ClassKind.MeasurementScale, this.measurementScale.Container)).Returns(true);
+            var session = new Mock<ISession>();
+            session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+            this.messageBus = new CDPMessageBus();
+
+            this.viewModel = new MeasurementScalesTableViewModel(this.sessionService.Object, this.showHideService.Object, this.messageBus, this.loggerMock.Object);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.messageBus.ClearSubscriptions();
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyInitializeViewModel()
+        {
+            this.viewModel.InitializeViewModel();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Rows.Count, Is.EqualTo(1));
+                Assert.That(this.viewModel.Rows.Items.First().MeasurementScale, Is.EqualTo(this.measurementScale));
+            });
+        }
+
+        [Test]
+        public void VerifyMeasurementScaleRowProperties()
+        {
+            this.viewModel.InitializeViewModel();
+            var measurementScaleRow = this.viewModel.Rows.Items.First();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(measurementScaleRow.ContainerName, Is.EqualTo("rdl"));
+                Assert.That(measurementScaleRow.Name, Is.EqualTo(this.measurementScale.Name));
+                Assert.That(measurementScaleRow.ShortName, Is.EqualTo(this.measurementScale.ShortName));
+                Assert.That(measurementScaleRow.MeasurementScale, Is.EqualTo(this.measurementScale));
+                Assert.That(measurementScaleRow.IsAllowedToWrite, Is.EqualTo(true));
+                Assert.That(measurementScaleRow.Type, Is.EqualTo(nameof(OrdinalScale)));
+            });
+        }
+
+        [Test]
+        public void VerifySessionRefresh()
+        {
+            this.viewModel.InitializeViewModel();
+
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+
+            var siteReferenceDataLibrary = new SiteReferenceDataLibrary()
+            {
+                ShortName = "newShortname"
+            };
+
+            var scaleTest = new OrdinalScale()
+            {
+                Iid = Guid.NewGuid(),
+                Container = siteReferenceDataLibrary,
+                Unit = new SimpleUnit() { ShortName = "newSimpleUnit" },
+                NumberSet = NumberSetKind.INTEGER_NUMBER_SET
+            };
+
+            this.messageBus.SendObjectChangeEvent(scaleTest, EventKind.Added);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().MeasurementScale, EventKind.Removed);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().MeasurementScale, EventKind.Updated);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+
+            this.messageBus.SendObjectChangeEvent(siteReferenceDataLibrary, EventKind.Updated);
+            this.messageBus.SendObjectChangeEvent(new PersonRole(), EventKind.Updated);
+            this.messageBus.SendMessage(SessionStateKind.RefreshEnded);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Rows.Items.First().ContainerName, Is.EqualTo(siteReferenceDataLibrary.ShortName));
+                this.permissionService.Verify(x => x.CanWrite(ClassKind.MeasurementScale, It.IsAny<Thing>()), Times.AtLeast(this.viewModel.Rows.Count));
+            });
+        }
+        
+        [Test]
+         public async Task VerifyRowOperations()
+         {
+             this.viewModel.InitializeViewModel();
+             var measurementScaleRow = this.viewModel.Rows.Items.First();
+             measurementScaleRow.IsDeprecated = false;
+
+             Assert.Multiple(() =>
+             {
+                 Assert.That(measurementScaleRow, Is.Not.Null);
+                 Assert.That(this.viewModel.IsOnDeprecationMode, Is.EqualTo(false));
+             });
+
+             this.viewModel.OnDeprecateUnDeprecateButtonClick(measurementScaleRow);
+
+             Assert.Multiple(() =>
+             {
+                 Assert.That(this.viewModel.IsOnDeprecationMode, Is.EqualTo(true));
+                 Assert.That(this.viewModel.MeasurementScale, Is.EqualTo(measurementScaleRow.MeasurementScale));
+             });
+             
+             this.viewModel.OnCancelPopupButtonClick();
+             Assert.That(this.viewModel.IsOnDeprecationMode, Is.EqualTo(false));
+
+             await this.viewModel.OnConfirmPopupButtonClick();
+             this.sessionService.Verify(x => x.UpdateThings(It.IsAny<SiteDirectory>(), It.Is<MeasurementScale>(c => c.IsDeprecated == true)));
+
+             this.viewModel.MeasurementScale.IsDeprecated = true;
+             await this.viewModel.OnConfirmPopupButtonClick();
+             this.sessionService.Verify(x => x.UpdateThings(It.IsAny<SiteDirectory>(), It.Is<MeasurementScale>(c => c.IsDeprecated == false)));
+        }
+    }
+}

--- a/COMETwebapp/Components/ReferenceData/MeasurementScalesTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScalesTable.razor
@@ -1,0 +1,118 @@
+﻿<!------------------------------------------------------------------------------
+Copyright (c) 2023-2024 RHEA System S.A.
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+    This file is part of CDP4-COMET WEB Community Edition
+     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+@using COMETwebapp.ViewModels.Components.ReferenceData.Rows
+@using CDP4Common.SiteDirectoryData
+@inherits DisposableComponent
+
+<LoadingComponent IsVisible="@this.ViewModel.IsLoading">
+    <DxGrid @ref="this.Grid"
+            Data="this.ViewModel.Rows.Items"
+            ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
+            ShowSearchBox="true"
+            ShowAllRows="true"
+            SearchBoxNullText="Search for a measurement scale ..."
+            PopupEditFormCssClass="pw-800"
+            PopupEditFormHeaderText="Measurement Scale (UNDER DEV)"
+            CustomizeElement="DisableDeprecatedMeasurementScale"
+            EditMode="GridEditMode.PopupEditForm"
+            EditModelSaving="@(this.OnEditMeasurementScaleSaving)"
+            CustomizeEditModel="this.CustomizeEditMeasurementScale">
+        <Columns>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Name)" MinWidth="150" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Type)" Caption="Type" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.NumberSet)" Caption="Number Set" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Unit)" Caption="Unit" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ContainerName)" Caption="Container RDL" MinWidth="80" SearchEnabled="false" />
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.IsDeprecated)" UnboundType="GridUnboundColumnType.Boolean" Visible="false" Caption="Is Deprecated" MinWidth="80" SearchEnabled="false" />
+            <DxGridCommandColumn Width="200px" EditButtonVisible="false">
+                <HeaderTemplate>
+                    <DxButton Id="addMeasurementScaleButton" Text="Add Measurement Scale" IconCssClass="oi oi-plus" Click="() => this.Grid.StartEditNewRowAsync()"/>
+                </HeaderTemplate>
+                <CellDisplayTemplate>
+                    @{
+                        var row = (MeasurementScaleRowViewModel)context.DataItem;
+
+                        <DxButton Id="editScaleButton" Text="Edit" Click="@(() => this.Grid.StartEditRowAsync(context.VisibleIndex))" Enabled="@(row.IsAllowedToWrite)" />
+                        <DxButton Id="@(row.IsDeprecated ? "undeprecateButton" : "deprecateButton")"
+                                  Text="@(row.IsDeprecated ? "Un-deprecate" : "Deprecate")"
+                                  Click="() => this.ViewModel.OnDeprecateUnDeprecateButtonClick(row)" 
+                                  Enabled="@(row.IsAllowedToWrite)" />
+                    }
+                </CellDisplayTemplate>
+            </DxGridCommandColumn>
+        </Columns>
+        
+        <EditFormTemplate Context="EditFormContext">
+            <DxFormLayout CssClass="w-100">
+                <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementScale.ShortName" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementScale.Name" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Library:" ColSpanMd="10">
+                    <DxComboBox Data="@this.ViewModel.ReferenceDataLibraries"
+                                TextFieldName="@nameof(ReferenceDataLibrary.ShortName)"
+                                @bind-Value="@this.ViewModel.MeasurementScale.Container"
+                                CssClass="cw-480" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Unit:" ColSpanMd="10">
+                    <DxComboBox Data="@this.ViewModel.MeasurementUnits"
+                                TextFieldName="@nameof(MeasurementUnit.ShortName)"
+                                @bind-Value="@this.ViewModel.MeasurementScale.Unit"
+                                CssClass="cw-480" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Number set:" ColSpanMd="10">
+                    <DxComboBox Data="@this.ViewModel.NumberSetKinds"
+                                @bind-Value="@this.ViewModel.MeasurementScale.NumberSet"
+                                CssClass="cw-480" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Maximum Permissible Value:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementScale.MaximumPermissibleValue" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Minimum Permissible Value:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementScale.MinimumPermissibleValue" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Positive Value Connotation:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementScale.PositiveValueConnotation" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Negative Value Connotation:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.MeasurementScale.NegativeValueConnotation" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Minimum Inclusive:" ColSpanMd="6">
+                    <DxCheckBox @bind-Checked="@this.ViewModel.MeasurementScale.IsMinimumInclusive" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Maximum Inclusive:" ColSpanMd="6">
+                    <DxCheckBox @bind-Checked="@this.ViewModel.MeasurementScale.IsMaximumInclusive" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
+                    <DxCheckBox @bind-Checked="@this.ViewModel.MeasurementScale.IsDeprecated" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+        </EditFormTemplate>
+
+    </DxGrid>
+    
+    <DxPopup @bind-Visible="@this.ViewModel.IsOnDeprecationMode" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
+        @this.ViewModel.PopupDialog
+        <div class="dxbl-grid-confirm-dialog-buttons">
+            <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@this.ViewModel.OnCancelPopupButtonClick" />
+            <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@this.ViewModel.OnConfirmPopupButtonClick" />
+        </div>
+    </DxPopup>
+</LoadingComponent>

--- a/COMETwebapp/Components/ReferenceData/MeasurementScalesTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScalesTable.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="MeasurementUnitsTable.razor.cs" company="RHEA System S.A.">
+// <copyright file="MeasurementScalesTable.razor.cs" company="RHEA System S.A.">
 //    Copyright (c) 2023-2024 RHEA System S.A.
 //
 //    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
@@ -42,20 +42,20 @@ namespace COMETwebapp.Components.ReferenceData
     using ReactiveUI;
 
     /// <summary>
-    /// Support class for the <see cref="MeasurementUnitsTable"/>
+    /// Support class for the <see cref="MeasurementScalesTable"/>
     /// </summary>
-    public partial class MeasurementUnitsTable
+    public partial class MeasurementScalesTable
     {
         /// <summary>
-        /// The <see cref="IMeasurementUnitsTableViewModel" /> for this component
+        /// The <see cref="IMeasurementScalesTableViewModel" /> for this component
         /// </summary>
         [Inject]
-        public IMeasurementUnitsTableViewModel ViewModel { get; set; }
+        public IMeasurementScalesTableViewModel ViewModel { get; set; }
 
         /// <summary>
-        /// Gets or sets the condition to check if a measurement unit should be created
+        /// Gets or sets the condition to check if a measurement scale should be created
         /// </summary>
-        public bool ShouldCreateMeasurementUnit { get; private set; }
+        public bool ShouldCreateMeasurementScale { get; private set; }
 
         /// <summary>
         /// Gets or sets the grid control that is being customized.
@@ -119,24 +119,24 @@ namespace COMETwebapp.Components.ReferenceData
         }
 
         /// <summary>
-        /// Method that is invoked when the edit/add measurement unit form is being saved
+        /// Method that is invoked when the edit/add measurement scale form is being saved
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
-        private void OnEditMeasurementUnitSaving()
+        private void OnEditMeasurementScaleSaving()
         {
-            if (!this.ShouldCreateMeasurementUnit)
+            if (!this.ShouldCreateMeasurementScale)
             {
-                // update measurement unit
+                // update measurement scale
             }
 
-            // create measurement unit
+            // create measurement scale
         }
 
         /// <summary>
-        /// Method invoked to highlight deprecated measurement units
+        /// Method invoked to highlight deprecated measurement scakes
         /// </summary>
         /// <param name="e">A <see cref="GridCustomizeElementEventArgs"/> </param>
-        private static void DisableDeprecatedMeasurementUnit(GridCustomizeElementEventArgs e)
+        private static void DisableDeprecatedMeasurementScale(GridCustomizeElementEventArgs e)
         {
             if (e.ElementType == GridElementType.DataRow && (bool)e.Grid.GetRowValue(e.VisibleIndex, "IsDeprecated"))
             {
@@ -145,23 +145,23 @@ namespace COMETwebapp.Components.ReferenceData
         }
 
         /// <summary>
-        /// Method invoked when creating a new measurement unit
+        /// Method invoked when creating a new measurement scale
         /// </summary>
         /// <param name="e">A <see cref="GridCustomizeEditModelEventArgs" /></param>
-        private void CustomizeEditMeasurementUnit(GridCustomizeEditModelEventArgs e)
+        private void CustomizeEditMeasurementScale(GridCustomizeEditModelEventArgs e)
         {
-            var dataItem = (MeasurementUnitRowViewModel)e.DataItem;
-            this.ShouldCreateMeasurementUnit = e.IsNew;
+            var dataItem = (MeasurementScaleRowViewModel)e.DataItem;
+            this.ShouldCreateMeasurementScale = e.IsNew;
 
             if (dataItem == null)
             {
-                e.EditModel = new SimpleUnit();
-                this.ViewModel.MeasurementUnit = new SimpleUnit();
+                e.EditModel = new OrdinalScale();
+                this.ViewModel.MeasurementScale = new OrdinalScale();
                 return;
             }
 
             e.EditModel = dataItem;
-            this.ViewModel.MeasurementUnit = dataItem.MeasurementUnit.Clone(true);
+            this.ViewModel.MeasurementScale = dataItem.MeasurementScale.Clone(true);
         }
     }
 }

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnitsTable.razor
@@ -26,7 +26,7 @@ Copyright (c) 2023-2024 RHEA System S.A.
             ShowAllRows="true"
             SearchBoxNullText="Search for a measurement unit ..."
             PopupEditFormCssClass="pw-800"
-            PopupEditFormHeaderText="Create Measurement Unit (UNDER DEV)"
+            PopupEditFormHeaderText="Measurement Unit (UNDER DEV)"
             CustomizeElement="DisableDeprecatedMeasurementUnit"
             EditMode="GridEditMode.PopupEditForm"
             EditModelSaving="@(this.OnEditMeasurementUnitSaving)"

--- a/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
+++ b/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
@@ -85,6 +85,7 @@ namespace COMETwebapp.Extensions
             serviceCollection.AddTransient<IElementDefinitionTableViewModel, ElementDefinitionTableViewModel>();
             serviceCollection.AddTransient<IBookEditorBodyViewModel, BookEditorBodyViewModel>();
             serviceCollection.AddTransient<IMeasurementUnitsTableViewModel, MeasurementUnitsTableViewModel>();
+            serviceCollection.AddTransient<IMeasurementScalesTableViewModel, MeasurementScalesTableViewModel>();
         }
     }
 }

--- a/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor
+++ b/COMETwebapp/Pages/ReferenceData/ReferenceDataPage.razor
@@ -21,6 +21,7 @@ Copyright (c) 2023-2024 RHEA System S.A.
 <DxToolbar ItemClick="@this.OnItemClick">
     <Items>
         <DxToolbarItem Name="ParameterTypes" Text="Parameter Types" Tooltip="Parameter Types" />
+        <DxToolbarItem Name="MeasurementScales" Text="Measurement Scales" Tooltip="Measurement Scales" />
         <DxToolbarItem Name="MeasurementUnits" Text="Measurement Units" Tooltip="Measurement Units" />
         <DxToolbarItem Name="Categories" Text="Categories" Tooltip="Categories" />
     </Items>
@@ -36,5 +37,8 @@ Copyright (c) 2023-2024 RHEA System S.A.
         break;
     case "MeasurementUnits":
         <MeasurementUnitsTable />
+        break;
+    case "MeasurementScales":
+        <MeasurementScalesTable />
         break;
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementScalesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/IMeasurementScalesTableViewModel.cs
@@ -1,0 +1,117 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IMeasurementScalesTableViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DynamicData;
+
+    /// <summary>
+    /// View model used to manage <see cref="MeasurementScale" />s
+    /// </summary>
+    public interface IMeasurementScalesTableViewModel : IApplicationBaseViewModel, IHaveReusableRows
+    {
+        /// <summary>
+        /// Gets or sets the data source for the grid control.
+        /// </summary>
+        SourceList<MeasurementScale> DataSource { get; }
+
+        /// <summary>
+        /// A reactive collection of <see cref="MeasurementScaleRowViewModel" />
+        /// </summary>
+        SourceList<MeasurementScaleRowViewModel> Rows { get; }
+
+        /// <summary>
+        /// Injected property to get access to <see cref="IShowHideDeprecatedThingsService" />
+        /// </summary>
+        IShowHideDeprecatedThingsService ShowHideDeprecatedThingsService { get; }
+
+        /// <summary>
+        /// The <see cref="MeasurementScale" /> to create or edit
+        /// </summary>
+        MeasurementScale MeasurementScale { get; set; }
+
+        /// <summary>
+        /// Indicates if confirmation popup is visible
+        /// </summary>
+        bool IsOnDeprecationMode { get; set; }
+
+        /// <summary>
+        /// popup message dialog
+        /// </summary>
+        string PopupDialog { get; set; }
+
+        /// <summary>
+        /// Gets the available <see cref="ReferenceDataLibrary" />s
+        /// </summary>
+        IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; }
+
+        /// <summary>
+        /// Gets the available <see cref="MeasurementUnit" />s
+        /// </summary>
+        IEnumerable<MeasurementUnit> MeasurementUnits { get; }
+
+        /// <summary>
+        /// Gets the available <see cref="NumberSetKind" />s
+        /// </summary>
+        IEnumerable<NumberSetKind> NumberSetKinds { get; }
+
+        /// <summary>
+        /// Method invoked when confirming the deprecation/un-deprecation of a <see cref="MeasurementScalesTableViewModel.MeasurementScale" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        Task OnConfirmPopupButtonClick();
+
+        /// <summary>
+        /// Method invoked when canceling the deprecation/un-deprecation of a <see cref="MeasurementScalesTableViewModel.MeasurementScale" />
+        /// </summary>
+        void OnCancelPopupButtonClick();
+
+        /// <summary>
+        /// Action invoked when the deprecate or undeprecate button is clicked
+        /// </summary>
+        /// <param name="measurementScaleRow"> The <see cref="MeasurementScaleRowViewModel" /> to deprecate or undeprecate </param>
+        void OnDeprecateUnDeprecateButtonClick(MeasurementScaleRowViewModel measurementScaleRow);
+
+        /// <summary>
+        /// Method invoked when the component is ready to start, having received its
+        /// initial parameters from its parent in the render tree.
+        /// Override this method if you will perform an asynchronous operation and
+        /// want the component to refresh when that operation is completed.
+        /// </summary>
+        void InitializeViewModel();
+
+        /// <summary>
+        /// Tries to deprecate or undeprecate a <see cref="MeasurementScalesTableViewModel.MeasurementScale" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        Task DeprecatingOrUnDeprecatingMeasurementScale();
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModel.cs
@@ -1,0 +1,327 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementScalesTableViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2023-2024 RHEA System S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using CDP4Dal.Permission;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DynamicData;
+
+    using ReactiveUI;
+
+    using MeasurementScale = CDP4Common.SiteDirectoryData.MeasurementScale;
+
+    /// <summary>
+    /// View model used to manage <see cref="MeasurementScale" />s
+    /// </summary>
+    public class MeasurementScalesTableViewModel : ApplicationBaseViewModel, IMeasurementScalesTableViewModel
+    {
+        /// <summary>
+        /// Injected property to get access to <see cref="IPermissionService" />
+        /// </summary>
+        private readonly IPermissionService permissionService;
+
+        /// <summary>
+        /// Injected property to get access to <see cref="ISessionService" />
+        /// </summary>
+        private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// Backing field for <see cref="IsOnDeprecationMode" />
+        /// </summary>
+        private bool isOnDeprecationMode;
+
+        /// <summary>
+        /// The <see cref="ILogger{TCategoryName}"/>
+        /// </summary>
+        private readonly ILogger<MeasurementScalesTableViewModel> logger;
+
+        /// <summary>
+        /// A collection of <see cref="Type" /> used to create <see cref="ObjectChangedEvent" /> subscriptions
+        /// </summary>
+        private static readonly IEnumerable<Type> ObjectChangedTypesOfInterest = new List<Type>
+        {
+            typeof(MeasurementScale),
+            typeof(PersonRole),
+            typeof(ReferenceDataLibrary)
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeasurementScalesTableViewModel" /> class.
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /></param>
+        /// <param name="showHideDeprecatedThingsService">The <see cref="IShowHideDeprecatedThingsService" /></param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus"/></param>
+        /// <param name="logger">The <see cref="ILogger{TCategoryName}"/></param>
+        public MeasurementScalesTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, 
+            ILogger<MeasurementScalesTableViewModel> logger) : base(sessionService, messageBus)
+        {
+            this.sessionService = sessionService;
+            this.permissionService = sessionService.Session.PermissionService;
+            this.ShowHideDeprecatedThingsService = showHideDeprecatedThingsService;
+            this.logger = logger;
+
+            this.InitializeSubscriptions(ObjectChangedTypesOfInterest);
+            this.RegisterViewModelWithReusableRows(this);
+        }
+
+        /// <summary>
+        /// The <see cref="MeasurementScale" /> to create or edit
+        /// </summary>
+        public MeasurementScale MeasurementScale { get; set; } = new OrdinalScale();
+
+        /// <summary>
+        /// Gets the available <see cref="ReferenceDataLibrary" />s
+        /// </summary>
+        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; private set; }
+
+        /// <summary>
+        /// Gets the available <see cref="MeasurementUnit" />s
+        /// </summary>
+        public IEnumerable<MeasurementUnit> MeasurementUnits { get; private set; }
+
+        /// <summary>
+        /// Gets the available <see cref="NumberSetKind" />s
+        /// </summary>
+        public IEnumerable<NumberSetKind> NumberSetKinds { get; private set; } = Enum.GetValues<NumberSetKind>();
+
+        /// <summary>
+        /// Injected property to get access to <see cref="IShowHideDeprecatedThingsService" />
+        /// </summary>
+        public IShowHideDeprecatedThingsService ShowHideDeprecatedThingsService { get; }
+
+        /// <summary>
+        /// A reactive collection of <see cref="MeasurementScaleRowViewModel" />
+        /// </summary>
+        public SourceList<MeasurementScaleRowViewModel> Rows { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the data source for the grid control.
+        /// </summary>
+        public SourceList<MeasurementScale> DataSource { get; } = new();
+
+        /// <summary>
+        /// Indicates if confirmation popup is visible
+        /// </summary>
+        public bool IsOnDeprecationMode
+        {
+            get => this.isOnDeprecationMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnDeprecationMode, value);
+        }
+
+        /// <summary>
+        /// popup message dialog
+        /// </summary>
+        public string PopupDialog { get; set; }
+
+        /// <summary>
+        /// Initializes the <see cref="MeasurementScalesTableViewModel"/>
+        /// </summary>
+        public void InitializeViewModel()
+        {
+            this.ReferenceDataLibraries = this.sessionService.Session.RetrieveSiteDirectory().AvailableReferenceDataLibraries();
+            var availableMeasurementUnits = new List<MeasurementUnit>();
+
+            foreach (var referenceDataLibrary in this.ReferenceDataLibraries)
+            {
+                this.DataSource.AddRange(referenceDataLibrary.Scale);
+                availableMeasurementUnits.AddRange(referenceDataLibrary.Unit);
+            }
+
+            this.MeasurementUnits = availableMeasurementUnits;
+            this.Rows.AddRange(this.DataSource.Items.Select(x => new MeasurementScaleRowViewModel(x)));
+            this.RefreshAccessRight();
+        }
+
+        /// <summary>
+        /// Method invoked when confirming the deprecation/un-deprecation of a <see cref="MeasurementScale" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task OnConfirmPopupButtonClick()
+        {
+            await this.DeprecatingOrUnDeprecatingMeasurementScale();
+            this.IsOnDeprecationMode = false;
+        }
+
+        /// <summary>
+        /// Method invoked when canceling the deprecation/un-deprecation of a <see cref="MeasurementScale" />
+        /// </summary>
+        public void OnCancelPopupButtonClick()
+        {
+            this.IsOnDeprecationMode = false;
+        }
+
+        /// <summary>
+        /// Action invoked when the deprecate or undeprecate button is clicked
+        /// </summary>
+        /// <param name="measurementScaleRow"> The <see cref="MeasurementScaleRowViewModel" /> to deprecate or undeprecate </param>
+        public void OnDeprecateUnDeprecateButtonClick(MeasurementScaleRowViewModel measurementScaleRow)
+        {
+            this.MeasurementScale = measurementScaleRow.MeasurementScale;
+            this.PopupDialog = this.MeasurementScale.IsDeprecated ? "You are about to un-deprecate the measurement scale: " + measurementScaleRow.Name : "You are about to deprecate the measurement scale: " + measurementScaleRow.Name;
+            this.IsOnDeprecationMode = true;
+        }
+
+        /// <summary>
+        /// Tries to deprecate or undeprecate a <see cref="MeasurementScale" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task DeprecatingOrUnDeprecatingMeasurementScale()
+        {
+            var siteDirectoryClone = this.sessionService.GetSiteDirectory().Clone(false);
+            var clonedMeasurementScale = this.MeasurementScale.Clone(false);
+            clonedMeasurementScale.IsDeprecated = !clonedMeasurementScale.IsDeprecated;
+
+            try
+            {
+                await this.sessionService.UpdateThings(siteDirectoryClone, clonedMeasurementScale);
+                await this.sessionService.RefreshSession();
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "An error has occurred while trying to deprecating or un-deprecating the measurement scale {scaleName}", clonedMeasurementScale.ShortName);
+            }
+        }
+
+        /// <summary>
+        /// Add rows related to <see cref="Thing" /> that has been added
+        /// </summary>
+        /// <param name="addedThings">A collection of added <see cref="Thing" /></param>
+        public void AddRows(IEnumerable<Thing> addedThings)
+        {
+            var addedMeasurementScales = addedThings.OfType<MeasurementScale>().ToList();
+            this.Rows.AddRange(addedMeasurementScales.Select(x => new MeasurementScaleRowViewModel(x)));
+        }
+
+        /// <summary>
+        /// Updates rows related to <see cref="Thing" /> that have been updated
+        /// </summary>
+        /// <param name="updatedThings">A collection of updated <see cref="Thing" /></param>
+        public void UpdateRows(IEnumerable<Thing> updatedThings)
+        {
+            var updatedThingsList = updatedThings.ToList();
+
+            var updatedMeasurementScales = updatedThingsList.OfType<MeasurementScale>();
+            var updatedPersonRoles = updatedThingsList.OfType<PersonRole>();
+            var updatedRdls = updatedThingsList.OfType<ReferenceDataLibrary>();
+
+            this.Rows.Edit(action =>
+            {
+                foreach (var updatedMeasurementScale in updatedMeasurementScales)
+                {
+                    var updatedRow = new MeasurementScaleRowViewModel(updatedMeasurementScale);
+                    var rowToUpdate = this.Rows.Items.First(x => x.MeasurementScale.Iid == updatedMeasurementScale.Iid);
+                    action.Replace(rowToUpdate, updatedRow);
+                }
+            });
+
+            foreach (var rdl in updatedRdls)
+            {
+                this.RefreshContainerName(rdl);
+            }
+
+            if (updatedPersonRoles.Any())
+            {
+                this.RefreshAccessRight();
+            }
+        }
+
+        /// <summary>
+        /// Remove rows related to a <see cref="Thing" /> that has been deleted
+        /// </summary>
+        /// <param name="deletedThings">A collection of deleted <see cref="Thing" /></param>
+        public void RemoveRows(IEnumerable<Thing> deletedThings)
+        {
+            var measurementScalesIidsToRemove = deletedThings.OfType<MeasurementScale>().Select(x => x.Iid);
+            var rowsToDelete = this.Rows.Items.Where(x => measurementScalesIidsToRemove.Contains(x.MeasurementScale.Iid)).ToList();
+
+            this.Rows.RemoveMany(rowsToDelete);
+        }
+
+        /// <summary>
+        /// Handles the refresh of the current <see cref="ISession" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override Task OnSessionRefreshed()
+        {
+            if (this.AddedThings.Count == 0 && this.UpdatedThings.Count == 0 && this.DeletedThings.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            this.IsLoading = true;
+            this.UpdateInnerComponents();
+            this.RefreshAccessRight();
+            this.ClearRecordedChanges();
+            this.IsLoading = false;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Refresh the displayed container name for the measurement scale rows
+        /// </summary>
+        /// <param name="rdl">
+        /// The updated <see cref="ReferenceDataLibrary" />.
+        /// </param>
+        private void RefreshContainerName(ReferenceDataLibrary rdl)
+        {
+            this.IsLoading = true;
+            var rowsContainedByUpdatedRdl = this.Rows.Items.Where(x => x.MeasurementScale.Container.Iid == rdl.Iid);
+
+            foreach (var measurementScale in rowsContainedByUpdatedRdl)
+            {
+                measurementScale.ContainerName = rdl.ShortName;
+            }
+
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Updates the active user access rights
+        /// </summary>
+        private void RefreshAccessRight()
+        {
+            this.IsLoading = true;
+
+            foreach (var row in this.Rows.Items)
+            {
+                row.IsAllowedToWrite = this.permissionService.CanWrite(ClassKind.MeasurementScale, row.MeasurementScale.Container);
+            }
+
+            this.IsLoading = false;
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementScaleRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementScaleRowViewModel.cs
@@ -1,0 +1,170 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MeasurementScaleRowViewModel.cs" company="RHEA System S.A.">
+//     Copyright (c) 2023-2024 RHEA System S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData.Rows
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Row View Model for  <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" />
+    /// </summary>
+    public class MeasurementScaleRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="ContainerName" />
+        /// </summary>
+        private string containerName;
+
+        /// <summary>
+        /// Backing field for <see cref="IsDeprecated" />
+        /// </summary>
+        private bool isDeprecated;
+
+        /// <summary>
+        /// Backing field for <see cref="Name" />
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// Backing field for <see cref="ShortName" />
+        /// </summary>
+        private string shortName;
+
+        /// <summary>
+        /// Backing field for <see cref="Type" />
+        /// </summary>
+        private string type;
+
+        /// <summary>
+        /// Backing field for <see cref="NumberSet" />
+        /// </summary>
+        private string numberSet;
+
+        /// <summary>
+        /// Backing field for <see cref="Unit" />
+        /// </summary>
+        private string unit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeasurementScaleRowViewModel" /> class.
+        /// </summary>
+        /// <param name="measurementScale">The associated <see cref="MeasurementScale" /></param>
+        public MeasurementScaleRowViewModel(MeasurementScale measurementScale)
+        {
+            this.MeasurementScale = measurementScale;
+            this.Name = measurementScale.Name;
+            this.ShortName = measurementScale.ShortName;
+            this.Type = measurementScale.ClassKind.ToString();
+            var container = (ReferenceDataLibrary)measurementScale.Container;
+            this.ContainerName = container.ShortName;
+            this.NumberSet = measurementScale.NumberSet.ToString();
+            this.Unit = measurementScale.Unit.ShortName;
+            this.IsDeprecated = measurementScale.IsDeprecated;
+        }
+
+        /// <summary>
+        /// The associated <see cref="MeasurementScale" />
+        /// </summary>
+        public MeasurementScale MeasurementScale { get; private set; }
+
+        /// <summary>
+        /// The name of the <see cref="MeasurementScale" />
+        /// </summary>
+        public string Name
+        {
+            get => this.name;
+            set => this.RaiseAndSetIfChanged(ref this.name, value);
+        }
+
+        /// <summary>
+        /// The short name of the <see cref="MeasurementScale" />
+        /// </summary>
+        public string ShortName
+        {
+            get => this.shortName;
+            set => this.RaiseAndSetIfChanged(ref this.shortName, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" /> type
+        /// </summary>
+        public string Type
+        {
+            get => this.type;
+            set => this.RaiseAndSetIfChanged(ref this.type, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" /> container name
+        /// </summary>
+        public string ContainerName
+        {
+            get => this.containerName;
+            set => this.RaiseAndSetIfChanged(ref this.containerName, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" /> number set
+        /// </summary>
+        public string NumberSet
+        {
+            get => this.numberSet;
+            set => this.RaiseAndSetIfChanged(ref this.numberSet, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" /> measurement unit
+        /// </summary>
+        public string Unit
+        {
+            get => this.unit;
+            set => this.RaiseAndSetIfChanged(ref this.unit, value);
+        }
+
+        /// <summary>
+        /// Value indicating if the <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" /> is deprecated
+        /// </summary>
+        public bool IsDeprecated
+        {
+            get => this.isDeprecated;
+            set => this.RaiseAndSetIfChanged(ref this.isDeprecated, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="IsAllowedToWrite" />
+        /// </summary>
+        private bool isAllowedToWrite;
+
+        /// <summary>
+        /// Value indicating if the <see cref="CDP4Common.SiteDirectoryData.MeasurementScale" /> is deprecated
+        /// </summary>
+        public bool IsAllowedToWrite
+        {
+            get => this.isAllowedToWrite;
+            set => this.RaiseAndSetIfChanged(ref this.isAllowedToWrite, value);
+        }
+    }
+}


### PR DESCRIPTION
- layout for create/edit implemented
- unit tests done

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #542 [Reference Data] Measurement Scales - display #542

- Added deprecate/undeprecate functionalities
- Table rows are reactive to session events
- Placeholders created for further create/edit features

